### PR TITLE
CustomOverlay 클러스터링

### DIFF
--- a/docs/docs/sample/library/basicClusterer.mdx
+++ b/docs/docs/sample/library/basicClusterer.mdx
@@ -49,3 +49,58 @@ function(){
   );
 }
 ```
+
+커스텀 오버레이 또한 클러스터링 가능합니다.
+
+```jsx live
+function(){
+  const [positions, setPositions] = useState([]);
+
+  useEffect(() => {
+    setPositions(clusterPositionsData.positions);
+  },[])
+
+  return (
+    <Map // 지도를 표시할 Container
+        center={{
+          // 지도의 중심좌표
+          lat: 36.2683,
+          lng: 127.6358,
+        }}
+        style={{
+          // 지도의 크기
+          width: "100%",
+          height: "450px",
+        }}
+        level={14} // 지도의 확대 레벨
+      >
+        <MarkerClusterer
+          averageCenter={true} // 클러스터에 포함된 마커들의 평균 위치를 클러스터 마커 위치로 설정
+          minLevel={10} // 클러스터 할 최소 지도 레벨
+        >
+          {positions.map((pos, idx) => (
+            <CustomOverlayMap
+              key={`${pos.lat}-${pos.lng}`}
+              position={{
+                lat: pos.lat,
+                lng: pos.lng,
+              }}
+            >
+              <div style={{
+                  color: "black",
+                  textAlign: "center",
+                  background: "white",
+                  width: "2rem",
+                  height: "2rem",
+                  borderRadius: "50%"
+                }}
+              >
+              {idx}
+              </div>
+            </CustomOverlayMap>
+          ))}
+        </MarkerClusterer>
+      </Map>
+  );
+}
+```

--- a/src/components/CustomOverlayMap.tsx
+++ b/src/components/CustomOverlayMap.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useMemo, useRef } from "react"
+import React, { useContext, useEffect, useMemo, useRef } from "react"
 import ReactDOM from "react-dom"
 import useMap from "../hooks/useMap"
+import { KakaoMapMarkerClustererContext } from "./MarkerClusterer"
 
 export interface CustomOverlayMapProps {
   /**
@@ -67,6 +68,8 @@ const CustomOverlayMap: React.FC<CustomOverlayMapProps> = ({
   zIndex,
   onCreate,
 }) => {
+  const markerCluster = useContext(KakaoMapMarkerClustererContext)
+
   const map = useMap(`CustomOverlayMap`)
   const container = useRef(document.createElement("div"))
 
@@ -92,11 +95,20 @@ const CustomOverlayMap: React.FC<CustomOverlayMapProps> = ({
   useEffect(() => {
     if (!map) return
 
-    overlay.setMap(map)
-    return () => {
-      overlay.setMap(null)
+    if (markerCluster) {
+      markerCluster.addMarker(overlay as unknown as kakao.maps.Marker)
+    } else {
+      overlay.setMap(map)
     }
-  }, [map, overlay])
+
+    return () => {
+      if (markerCluster) {
+        markerCluster.removeMarker(overlay as unknown as kakao.maps.Marker)
+      } else {
+        overlay.setMap(null)
+      }
+    }
+  }, [map, markerCluster, overlay])
 
   useEffect(() => {
     if (onCreate) onCreate(overlay)


### PR DESCRIPTION
https://github.com/JaeSeoKim/react-kakao-maps-sdk/issues/9
https://github.com/JaeSeoKim/kakao.maps.d.ts/pull/2

kakao.maps.d.ts에서 Marker 와 CustomOverlay를 유니온으로 설정 하면 더 깔끔하게 처리 할 수 있을 것 같습니다.