### PR TITLE
:arrow_up: Add the type FCWithChildren to support React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "kakao.maps.d.ts": "^0.1.26"
   },
   "peerDependencies": {
-    "react": ">=17.0.2 || >=16.9.0",
-    "react-dom": ">=17.0.2 || >=16.9.0"
+    "react": ">=18.0.0 || >=17.0.2 || >=16.9.0",
+    "react-dom": ">=18.0.0 || >=17.0.2 || >=16.9.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.21",

--- a/src/components/CustomOverlayMap.tsx
+++ b/src/components/CustomOverlayMap.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect, useMemo, useRef } from "react"
 import ReactDOM from "react-dom"
 import useMap from "../hooks/useMap"
-import { FCWithChildren } from "../types"
 import { KakaoMapMarkerClustererContext } from "./MarkerClusterer"
 
 export interface CustomOverlayMapProps {
@@ -57,7 +56,9 @@ export interface CustomOverlayMapProps {
  * Map에 CustomOverlay를 올릴 때 사용하는 컴포넌트 입니다.
  * `onCreate` 함수를 통해서 `CustomOverlay` 객체에 직접 접근 및 초기 설정 작업을 지정할 수 있습니다.
  */
-const CustomOverlayMap: FCWithChildren<CustomOverlayMapProps> = ({
+const CustomOverlayMap: React.FC<
+  React.PropsWithChildren<CustomOverlayMapProps>
+> = ({
   id,
   className,
   style,

--- a/src/components/CustomOverlayMap.tsx
+++ b/src/components/CustomOverlayMap.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useMemo, useRef } from "react"
 import ReactDOM from "react-dom"
 import useMap from "../hooks/useMap"
+import { FCWithChildren } from "../types"
 import { KakaoMapMarkerClustererContext } from "./MarkerClusterer"
 
 export interface CustomOverlayMapProps {
@@ -56,7 +57,7 @@ export interface CustomOverlayMapProps {
  * Map에 CustomOverlay를 올릴 때 사용하는 컴포넌트 입니다.
  * `onCreate` 함수를 통해서 `CustomOverlay` 객체에 직접 접근 및 초기 설정 작업을 지정할 수 있습니다.
  */
-const CustomOverlayMap: React.FC<CustomOverlayMapProps> = ({
+const CustomOverlayMap: FCWithChildren<CustomOverlayMapProps> = ({
   id,
   className,
   style,

--- a/src/components/CustomOverlayRoadview.tsx
+++ b/src/components/CustomOverlayRoadview.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef } from "react"
 import ReactDOM from "react-dom"
 import useRoadview from "../hooks/useRoadview"
-import { FCWithChildren } from "../types"
 
 export interface CustomOverlayRoadviewProps {
   /**
@@ -93,7 +92,9 @@ export interface CustomOverlayRoadviewProps {
  * Roadview에 CustomOverlay를 올릴 때 사용하는 컴포넌트 입니다.
  * `onCreate` 함수를 통해서 `CustomOverlay` 객체에 직접 접근 및 초기 설정 작업을 지정할 수 있습니다.
  */
-const CustomOverlayRoadview: FCWithChildren<CustomOverlayRoadviewProps> = ({
+const CustomOverlayRoadview: React.FC<
+  React.PropsWithChildren<CustomOverlayRoadviewProps>
+> = ({
   id,
   className,
   style,

--- a/src/components/CustomOverlayRoadview.tsx
+++ b/src/components/CustomOverlayRoadview.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef } from "react"
 import ReactDOM from "react-dom"
 import useRoadview from "../hooks/useRoadview"
+import { FCWithChildren } from "../types"
 
 export interface CustomOverlayRoadviewProps {
   /**
@@ -92,7 +93,7 @@ export interface CustomOverlayRoadviewProps {
  * Roadview에 CustomOverlay를 올릴 때 사용하는 컴포넌트 입니다.
  * `onCreate` 함수를 통해서 `CustomOverlay` 객체에 직접 접근 및 초기 설정 작업을 지정할 수 있습니다.
  */
-const CustomOverlayRoadview: React.FC<CustomOverlayRoadviewProps> = ({
+const CustomOverlayRoadview: FCWithChildren<CustomOverlayRoadviewProps> = ({
   id,
   className,
   style,

--- a/src/components/InfoWindow.tsx
+++ b/src/components/InfoWindow.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useRef } from "react"
 import ReactDom from "react-dom"
-import { FCWithChildren } from "../types"
 
 interface InfoWindowProps {
   /**
@@ -53,7 +52,7 @@ interface InfoWindowProps {
   onCreate?: (infoWindow: kakao.maps.InfoWindow) => void
 }
 
-const InfoWindow: FCWithChildren<InfoWindowProps> = ({
+const InfoWindow: React.FC<React.PropsWithChildren<InfoWindowProps>> = ({
   id,
   className,
   style,

--- a/src/components/InfoWindow.tsx
+++ b/src/components/InfoWindow.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef } from "react"
 import ReactDom from "react-dom"
+import { FCWithChildren } from "../types"
 
 interface InfoWindowProps {
   /**
@@ -52,7 +53,7 @@ interface InfoWindowProps {
   onCreate?: (infoWindow: kakao.maps.InfoWindow) => void
 }
 
-const InfoWindow: React.FC<InfoWindowProps> = ({
+const InfoWindow: FCWithChildren<InfoWindowProps> = ({
   id,
   className,
   style,

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react"
 import useKakaoEvent from "../hooks/useKakaoEvent"
+import { FCWithChildren } from "../types"
 
 export const KakaoMapContext = React.createContext<kakao.maps.Map>(
   undefined as unknown as kakao.maps.Map
@@ -219,7 +220,7 @@ export interface MapProps {
  * props로 받는 `on*` 이벤트는 해당 `kakao.maps.Map` 객체를 반환 합니다.
  * `onCreate` 이벤트를 통해 생성 후 `map` 객체에 직접 접근하여 초기 설정이 가능합니다.
  */
-const Map: React.FC<MapProps> = ({
+const Map: FCWithChildren<MapProps> = ({
   id = "kakao-map-container",
   style,
   children,

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from "react"
 import useKakaoEvent from "../hooks/useKakaoEvent"
-import { FCWithChildren } from "../types"
 
 export const KakaoMapContext = React.createContext<kakao.maps.Map>(
   undefined as unknown as kakao.maps.Map
@@ -220,7 +219,7 @@ export interface MapProps {
  * props로 받는 `on*` 이벤트는 해당 `kakao.maps.Map` 객체를 반환 합니다.
  * `onCreate` 이벤트를 통해 생성 후 `map` 객체에 직접 접근하여 초기 설정이 가능합니다.
  */
-const Map: FCWithChildren<MapProps> = ({
+const Map: React.FC<React.PropsWithChildren<MapProps>> = ({
   id = "kakao-map-container",
   style,
   children,

--- a/src/components/MapInfoWindow.tsx
+++ b/src/components/MapInfoWindow.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react"
 import InfoWindow from "./InfoWindow"
 import useMap from "../hooks/useMap"
-import { FCWithChildren } from "../types"
 
 export interface MapInfoWindowProps {
   /**
@@ -51,7 +50,7 @@ export interface MapInfoWindowProps {
  * Map 컴포넌트에서 InfoWindow를 그릴 때 사용됩니다.
  * `onCreate` 이벤트를 통해 생성 후 `infoWindow` 객체에 직접 접근하여 초기 설정이 가능합니다.
  */
-const MapInfoWindow: FCWithChildren<MapInfoWindowProps> = ({
+const MapInfoWindow: React.FC<React.PropsWithChildren<MapInfoWindowProps>> = ({
   id,
   className,
   style,

--- a/src/components/MapInfoWindow.tsx
+++ b/src/components/MapInfoWindow.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react"
 import InfoWindow from "./InfoWindow"
 import useMap from "../hooks/useMap"
+import { FCWithChildren } from "../types"
 
 export interface MapInfoWindowProps {
   /**
@@ -50,7 +51,7 @@ export interface MapInfoWindowProps {
  * Map 컴포넌트에서 InfoWindow를 그릴 때 사용됩니다.
  * `onCreate` 이벤트를 통해 생성 후 `infoWindow` 객체에 직접 접근하여 초기 설정이 가능합니다.
  */
-const MapInfoWindow: React.FC<MapInfoWindowProps> = ({
+const MapInfoWindow: FCWithChildren<MapInfoWindowProps> = ({
   id,
   className,
   style,

--- a/src/components/MapMarker.tsx
+++ b/src/components/MapMarker.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react"
 import useMap from "../hooks/useMap"
-import { FCWithChildren } from "../types"
 import Marker from "./Marker"
 
 export interface MapMarkerProps {
@@ -174,7 +173,7 @@ export interface MapMarkerProps {
  * Map에서 Marker를 생성할 때 사용 합니다.
  * `onCreate` 이벤트를 통해 생성 후 `maker` 객체에 직접 접근하여 초기 설정이 가능합니다.
  */
-const MapMarker: FCWithChildren<MapMarkerProps> = ({
+const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = ({
   image,
   position,
   children,

--- a/src/components/MapMarker.tsx
+++ b/src/components/MapMarker.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react"
 import useMap from "../hooks/useMap"
+import { FCWithChildren } from "../types"
 import Marker from "./Marker"
 
 export interface MapMarkerProps {
@@ -173,7 +174,7 @@ export interface MapMarkerProps {
  * Map에서 Marker를 생성할 때 사용 합니다.
  * `onCreate` 이벤트를 통해 생성 후 `maker` 객체에 직접 접근하여 초기 설정이 가능합니다.
  */
-const MapMarker: React.FC<MapMarkerProps> = ({
+const MapMarker: FCWithChildren<MapMarkerProps> = ({
   image,
   position,
   children,

--- a/src/components/Marker.tsx
+++ b/src/components/Marker.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useMemo } from "react"
 import useKakaoEvent from "../hooks/useKakaoEvent"
+import { FCWithChildren } from "../types"
 import InfoWindow from "./InfoWindow"
 import { KakaoMapMarkerClustererContext } from "./MarkerClusterer"
 
@@ -123,7 +124,7 @@ interface MarkerProps {
   }
 }
 
-const Marker: React.FC<MarkerProps> = ({
+const Marker: FCWithChildren<MarkerProps> = ({
   map,
   position,
   children,

--- a/src/components/Marker.tsx
+++ b/src/components/Marker.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useMemo } from "react"
 import useKakaoEvent from "../hooks/useKakaoEvent"
-import { FCWithChildren } from "../types"
 import InfoWindow from "./InfoWindow"
 import { KakaoMapMarkerClustererContext } from "./MarkerClusterer"
 
@@ -124,7 +123,7 @@ interface MarkerProps {
   }
 }
 
-const Marker: FCWithChildren<MarkerProps> = ({
+const Marker: React.FC<React.PropsWithChildren<MarkerProps>> = ({
   map,
   position,
   children,

--- a/src/components/MarkerClusterer.tsx
+++ b/src/components/MarkerClusterer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react"
 import useKakaoEvent from "../hooks/useKakaoEvent"
 import useMap from "../hooks/useMap"
+import { FCWithChildren } from "../types"
 
 export const KakaoMapMarkerClustererContext =
   React.createContext<kakao.maps.MarkerClusterer>(
@@ -116,7 +117,7 @@ export interface MarkerClustererProps {
   onCreate?: (target: kakao.maps.MarkerClusterer) => void
 }
 
-const MarkerClusterer: React.FC<MarkerClustererProps> = ({
+const MarkerClusterer: FCWithChildren<MarkerClustererProps> = ({
   children,
   averageCenter,
   calculator,

--- a/src/components/MarkerClusterer.tsx
+++ b/src/components/MarkerClusterer.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react"
 import useKakaoEvent from "../hooks/useKakaoEvent"
 import useMap from "../hooks/useMap"
-import { FCWithChildren } from "../types"
 
 export const KakaoMapMarkerClustererContext =
   React.createContext<kakao.maps.MarkerClusterer>(
@@ -117,7 +116,9 @@ export interface MarkerClustererProps {
   onCreate?: (target: kakao.maps.MarkerClusterer) => void
 }
 
-const MarkerClusterer: FCWithChildren<MarkerClustererProps> = ({
+const MarkerClusterer: React.FC<
+  React.PropsWithChildren<MarkerClustererProps>
+> = ({
   children,
   averageCenter,
   calculator,

--- a/src/components/Roadview.tsx
+++ b/src/components/Roadview.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react"
 import useKakaoEvent from "../hooks/useKakaoEvent"
+import { FCWithChildren } from "../types"
 
 export const KakaoRoadviewContext = React.createContext<kakao.maps.Roadview>(
   undefined as unknown as kakao.maps.Roadview
@@ -100,7 +101,7 @@ export interface RoadviewProps {
  * props로 받는 `on*` 이벤트는 해당 `kakao.maps.Map` 객체를 반환 합니다.
  * `onCreate` 이벤트를 통해 생성 후 `Roadview` 객체에 직접 접근하여 초기 설정이 가능합니다.
  */
-const Roadview: React.FC<RoadviewProps> = ({
+const Roadview: FCWithChildren<RoadviewProps> = ({
   id = "kakao-roadview-container",
   style,
   children,

--- a/src/components/Roadview.tsx
+++ b/src/components/Roadview.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from "react"
 import useKakaoEvent from "../hooks/useKakaoEvent"
-import { FCWithChildren } from "../types"
 
 export const KakaoRoadviewContext = React.createContext<kakao.maps.Roadview>(
   undefined as unknown as kakao.maps.Roadview
@@ -101,7 +100,7 @@ export interface RoadviewProps {
  * props로 받는 `on*` 이벤트는 해당 `kakao.maps.Map` 객체를 반환 합니다.
  * `onCreate` 이벤트를 통해 생성 후 `Roadview` 객체에 직접 접근하여 초기 설정이 가능합니다.
  */
-const Roadview: FCWithChildren<RoadviewProps> = ({
+const Roadview: React.FC<React.PropsWithChildren<RoadviewProps>> = ({
   id = "kakao-roadview-container",
   style,
   children,

--- a/src/components/RoadviewInfoWindow.tsx
+++ b/src/components/RoadviewInfoWindow.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react"
 import InfoWindow from "./InfoWindow"
 import useRoadview from "../hooks/useRoadview"
-import { FCWithChildren } from "../types"
 
 export interface RoadviewInfoWindowProps {
   /**
@@ -81,7 +80,9 @@ export interface RoadviewInfoWindowProps {
  * Map 컴포넌트에서 InfoWindow를 그릴 때 사용됩니다.
  * `onCreate` 이벤트를 통해 생성 후 `infoWindow` 객체에 직접 접근하여 초기 설정이 가능합니다.
  */
-const RoadviewInfoWindow: FCWithChildren<RoadviewInfoWindowProps> = ({
+const RoadviewInfoWindow: React.FC<
+  React.PropsWithChildren<RoadviewInfoWindowProps>
+> = ({
   id,
   className,
   style,

--- a/src/components/RoadviewInfoWindow.tsx
+++ b/src/components/RoadviewInfoWindow.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react"
 import InfoWindow from "./InfoWindow"
 import useRoadview from "../hooks/useRoadview"
+import { FCWithChildren } from "../types"
 
 export interface RoadviewInfoWindowProps {
   /**
@@ -80,7 +81,7 @@ export interface RoadviewInfoWindowProps {
  * Map 컴포넌트에서 InfoWindow를 그릴 때 사용됩니다.
  * `onCreate` 이벤트를 통해 생성 후 `infoWindow` 객체에 직접 접근하여 초기 설정이 가능합니다.
  */
-const RoadviewInfoWindow: React.FC<RoadviewInfoWindowProps> = ({
+const RoadviewInfoWindow: FCWithChildren<RoadviewInfoWindowProps> = ({
   id,
   className,
   style,

--- a/src/components/RoadviewMarker.tsx
+++ b/src/components/RoadviewMarker.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react"
 import useRoadview from "../hooks/useRoadview"
+import { FCWithChildren } from "../types"
 import Marker from "./Marker"
 
 export interface RoadviewMarkerProps {
@@ -181,7 +182,7 @@ export interface RoadviewMarkerProps {
  * Map에서 Marker를 생성할 때 사용 합니다.
  * `onCreate` 이벤트를 통해 생성 후 `maker` 객체에 직접 접근하여 초기 설정이 가능합니다.
  */
-const RoadviewMarker: React.FC<RoadviewMarkerProps> = ({
+const RoadviewMarker: FCWithChildren<RoadviewMarkerProps> = ({
   image,
   position,
   children,

--- a/src/components/RoadviewMarker.tsx
+++ b/src/components/RoadviewMarker.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react"
 import useRoadview from "../hooks/useRoadview"
-import { FCWithChildren } from "../types"
 import Marker from "./Marker"
 
 export interface RoadviewMarkerProps {
@@ -182,7 +181,9 @@ export interface RoadviewMarkerProps {
  * Map에서 Marker를 생성할 때 사용 합니다.
  * `onCreate` 이벤트를 통해 생성 후 `maker` 객체에 직접 접근하여 초기 설정이 가능합니다.
  */
-const RoadviewMarker: FCWithChildren<RoadviewMarkerProps> = ({
+const RoadviewMarker: React.FC<
+  React.PropsWithChildren<RoadviewMarkerProps>
+> = ({
   image,
   position,
   children,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,0 @@
-import React from "react"
-
-export type FCWithChildren<T> = React.FC<T & { children?: React.ReactNode }>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+import React from "react"
+
+export type FCWithChildren<T> = React.FC<T & { children?: React.ReactNode }>


### PR DESCRIPTION
This PR closes #12.

`children`을 받을 수 있는 컴포넌트들의 타입을 업데이트하여 React 18에서도 동작하게 했습니다.