### PR TITLE
Caching Dependencies to speed up workflows

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,13 +10,20 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        node-version: [16.x]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            docs/package-lock.json
       - name: install core dependency
         run: |
           npm ci

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -5,13 +5,17 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        node-version: [16.x]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
+          cache: npm
       - run: npm ci
       - run: npm run build
       - run: npm publish


### PR DESCRIPTION
## Description

Workflow에 의존성 캐싱을 추가하였습니다.

### About caching workflow dependencies

GitHub Actions의 워크플로우는 매번 새로운 가상환경에서 실행되기 때문에 의존성 패키지를 워크플로우마다 설치해야 합니다. 이 과정에서 네트워크의 사용이 증가하고 런타임이 길어지므로 결국 시간과 자원의 낭비로 이어지게 됩니다. 이러한 문제를 해결하기 위해 GitHub에서는 `의존성 캐싱` 기능을 지원합니다.

### Solutions

**AS-IS**

```yml
- uses: actions/setup-node@v1
  with:
     node-version: "16.x"
```

**TO-BE**

```yml
- uses: actions/setup-node@v3
  with:
     node-version: ${{ matrix.node-version }}
     cache: npm
```

>  ` cache: npm` 한 줄의 추가로 의존성 캐싱을 적용할 수 있습니다.

## References

- [Caching dependencies to speed up workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [더 빠른 워크플로우를 향해 | 아카이브-로그](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)