### PR TITLE
Fix docs(nextjs setup)

### DIFF
--- a/docs/docs/setup/next.md
+++ b/docs/docs/setup/next.md
@@ -12,24 +12,28 @@ Next.js 사용 시, Script 컴포넌트를 사용하여 Kakao 지도 API를 불�
 
 ## Example
 
-### \_app.js
+### \_document.js
 
 ```jsx
-import Script from "next/script"
+import { Html, Head, Main, NextScript } from "next/document";
+import Script from "next/script";
 
-function MyApp({ Component, pageProps }) {
+export default function Document() {
   return (
-    <>
-      <Script
-        src="//dapi.kakao.com/v2/maps/sdk.js?appkey=발급받은 APP KEY를 넣으시면 됩니다.&libraries=services,clusterer&autoload=false"
-        strategy="beforeInteractive"
-      />
-      <Component {...pageProps} />
-    </>
-  )
+    <Html>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+        <Script
+          src="//dapi.kakao.com/v2/maps/sdk.js?appkey=발급받은 APP KEY를 넣으시면 됩니다.&libraries=services,clusterer&autoload=false"
+          strategy="beforeInteractive"
+        />
+      </body>
+    </Html>
+  );
 }
 
-export default MyApp
 ```
 
 ### index.js


### PR DESCRIPTION
## 배경
ReactKakaoMapSDK 공식 문서 [Next.js 섹션의 예시](https://react-kakao-maps-sdk.jaeseokim.dev/docs/setup/next/#_appjs)에 따라 _app.js에 Script를 추가하였지만
다음과 같이 `Script`의 `beforeInteractive` 전략은 `pages/_document.js` 밖에서 사용돼서는 안 된다는 경고를 받았습니다.

<img width="1301" alt="스크린샷 2022-12-04 오후 7 20 25" src="https://user-images.githubusercontent.com/70563791/205485426-00543632-6d81-4fdc-8568-1198328a2c18.png">

## 변경한 것
[Next.js 공식 문서](https://nextjs.org/docs/messages/no-before-interactive-script-outside-document)에 따라 `Script`를 `pages/_document.js ` 내부에서 사용하는 것을 권장하도록 md 파일을 수정하였습니다.
