### PR TITLE
useKakaoEvent hook의 타입을 union 과 literal 타입을 이용하여 조금더 구체적으로 명시하기

### DIFF
--- a/src/hooks/useKakaoEvent.tsx
+++ b/src/hooks/useKakaoEvent.tsx
@@ -8,7 +8,7 @@ const useKakaoEvent = <T extends kakao.maps.event.EventTarget>(
   /**
    * event 타입
    */
-  type: string,
+  type: "center_changed"|"zoom_start"|"zoom_changed"|"bounds_changed"|"click"|"dblclick"|"rightclick"|"mouseover"|"mouseout"|"mousemove"|"mousedown"|"dragstart"|"drag"|"dragend"|"idle"|"tilesloaded"|"maptypeid_changed"|"clusterclick"|"clusterover"|"clusterout"|"clusterdblclick"|"clusterrightclick"|"clustered"|"init"|"panoid_changed"|"viewpoint_changed"|"position_changed",
   /**
    * 호출될 callback
    */


### PR DESCRIPTION
## 개선사항
kakao api가 자체적으로 처리하는 이벤트의 종류가 정해져있기에, event 타입으로 string 보다 해당되는 string을 union으로 명시하는것이 좋지 않을까 생각하였습니다. 그래서 타입에 현재 kakao에서 사용하는 이벤트를 모두 명시하였습니다. 명시한 타입의 순서는 kakao map api 공식문서를 참고하였습니다. 

## 기대효과
이벤트를 명시할때 타입추론을 받을수 있고, 오타발생확률을 낮출수 있습니다.

