### PR TITLE
An avoid issue that automatic assign crossorigin option in script

### DIFF
--- a/docs/docs/setup/next.md
+++ b/docs/docs/setup/next.md
@@ -27,6 +27,7 @@ export default function Document() {
         <NextScript />
         <Script
           src="//dapi.kakao.com/v2/maps/sdk.js?appkey=발급받은 APP KEY를 넣으시면 됩니다.&libraries=services,clusterer&autoload=false"
+          crossOrigin={undefined}
           strategy="beforeInteractive"
         />
       </body>


### PR DESCRIPTION
NextJS 14에서 production 빌드 후, next/script 컴포넌트를 사용하는 모든 것들은 crossorigin에 관해 기본적으로 same-origin으로 처리가되어서 정상적인 로드가 불가능합니다.

문서도 같이 업데이트 해주세요.