### PR TITLE
docs: Corrected inaccurate documentation of docs

### DIFF
--- a/docs/docs/sample/overlay/markerWithCustomOverlay.mdx
+++ b/docs/docs/sample/overlay/markerWithCustomOverlay.mdx
@@ -3,7 +3,7 @@ title: "이미지 마커와 커스텀 오버레이"
 sidebar_position: 24
 ---
 
-HTML과 CSS를 이용해 지도 위에 자유롭게 컨텐츠를 표시합니다. 이 샘플에서는 커스텀 오버레이를 마커 위에 표시하고 X버튼을 클릭했을 때 커스텀 오버레이를 지도에서 제거합니다. 마커를 클릭하면 다시 커스텀 오버레이가 표시됩니다.
+지도에 커스텀 오버레이와 마커 이미지를 이용해 다른 이미지로 마커를 표시합니다.
 
 > original docs : https://apis.map.kakao.com/web/sample/markerWithCustomOverlay/
 


### PR DESCRIPTION
아래 링크의 **이미지 마커와 커스텀 오버레이**  설명이 잘못되어 있어 수정하였습니다.
https://react-kakao-maps-sdk.jaeseokim.dev/docs/sample/overlay/markerWithCustomOverlay