### PR TITLE
:bug: Fix(#77): 일괄 처리를 적용하여 MarkerClusterer 렌더링 개선

### DIFF
--- a/dev/public/stations.json
+++ b/dev/public/stations.json
@@ -1,0 +1,35968 @@
+[
+  {
+    "statId": "익명_ID_1",
+    "statNm": "익명_충전소_1",
+    "addr": "익명_주소",
+    "lat": 37.60407059542486,
+    "lng": 126.9558097640352,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_2",
+    "statNm": "익명_충전소_2",
+    "addr": "익명_주소",
+    "lat": 37.58837151299668,
+    "lng": 127.02047529133336,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "05",
+        "stat": "9",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_3",
+    "statNm": "익명_충전소_3",
+    "addr": "익명_주소",
+    "lat": 37.551701827275515,
+    "lng": 127.01893081413768,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_4",
+    "statNm": "익명_충전소_4",
+    "addr": "익명_주소",
+    "lat": 37.58231040110078,
+    "lng": 126.93288448961003,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "051 709 XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_5",
+    "statNm": "익명_충전소_5",
+    "addr": "익명_주소",
+    "lat": 37.57520601935878,
+    "lng": 127.02640658011939,
+    "useTime": "07:00~19:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_6",
+    "statNm": "익명_충전소_6",
+    "addr": "익명_주소",
+    "lat": 37.546472858684446,
+    "lng": 126.9850045534013,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_7",
+    "statNm": "익명_충전소_7",
+    "addr": "익명_주소",
+    "lat": 37.53579577703606,
+    "lng": 126.94471242876536,
+    "useTime": "2025년 4월 이후로 사용 제한상태",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "21",
+        "chgerType": "04",
+        "stat": "4",
+        "output": 200
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "04",
+        "stat": "4",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_8",
+    "statNm": "익명_충전소_8",
+    "addr": "익명_주소",
+    "lat": 37.56825659616028,
+    "lng": 126.93013948057164,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_9",
+    "statNm": "익명_충전소_9",
+    "addr": "익명_주소",
+    "lat": 37.538064470374344,
+    "lng": 126.92770965255808,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_10",
+    "statNm": "익명_충전소_10",
+    "addr": "익명_주소",
+    "lat": 37.52311918219891,
+    "lng": 127.00123726077933,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 320
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 320
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_11",
+    "statNm": "익명_충전소_11",
+    "addr": "익명_주소",
+    "lat": 37.58371657973123,
+    "lng": 126.99929188479913,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_12",
+    "statNm": "익명_충전소_12",
+    "addr": "익명_주소",
+    "lat": 37.557433873208474,
+    "lng": 126.99357454150955,
+    "useTime": "19:00~22:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_13",
+    "statNm": "익명_충전소_13",
+    "addr": "익명_주소",
+    "lat": 37.52238551314294,
+    "lng": 127.03228107536953,
+    "useTime": "05:00 ~ 24:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_14",
+    "statNm": "익명_충전소_14",
+    "addr": "익명_주소",
+    "lat": 37.603724343498264,
+    "lng": 126.93118104153699,
+    "useTime": "06:30 ~ 23:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_15",
+    "statNm": "익명_충전소_15",
+    "addr": "익명_주소",
+    "lat": 37.547919389559446,
+    "lng": 126.95613527490985,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_16",
+    "statNm": "익명_충전소_16",
+    "addr": "익명_주소",
+    "lat": 37.55414588169382,
+    "lng": 127.03781315252564,
+    "useTime": "24시간 이용가능/소유주제한에따름",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_17",
+    "statNm": "익명_충전소_17",
+    "addr": "익명_주소",
+    "lat": 37.58102866341156,
+    "lng": 126.96942972315857,
+    "useTime": "24시간 이용가능/소유주제한에따름",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_18",
+    "statNm": "익명_충전소_18",
+    "addr": "익명_주소",
+    "lat": 37.54342938849741,
+    "lng": 127.00564033157265,
+    "useTime": "24시간 이용가능/소유주제한에따름",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_19",
+    "statNm": "익명_충전소_19",
+    "addr": "익명_주소",
+    "lat": 37.571708339244836,
+    "lng": 126.95047754162245,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따라 주차비가 발생할 수 있음 ",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_20",
+    "statNm": "익명_충전소_20",
+    "addr": "익명_주소",
+    "lat": 37.54940817357131,
+    "lng": 127.02351797189252,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_21",
+    "statNm": "익명_충전소_21",
+    "addr": "익명_주소",
+    "lat": 37.60219521994446,
+    "lng": 126.97430105600561,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_22",
+    "statNm": "익명_충전소_22",
+    "addr": "익명_주소",
+    "lat": 37.56163112509464,
+    "lng": 126.92331010483917,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_23",
+    "statNm": "익명_충전소_23",
+    "addr": "익명_주소",
+    "lat": 37.561501364110555,
+    "lng": 127.02397794042278,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_24",
+    "statNm": "익명_충전소_24",
+    "addr": "익명_주소",
+    "lat": 37.59978782326373,
+    "lng": 126.95688076964082,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "누구나 사용 가능",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_25",
+    "statNm": "익명_충전소_25",
+    "addr": "익명_주소",
+    "lat": 37.605100025437444,
+    "lng": 126.98269079815546,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "누구나 사용 가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_26",
+    "statNm": "익명_충전소_26",
+    "addr": "익명_주소",
+    "lat": 37.56371941969579,
+    "lng": 127.00504793149257,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "누구나 사용 가능",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_27",
+    "statNm": "익명_충전소_27",
+    "addr": "익명_주소",
+    "lat": 37.58035904227635,
+    "lng": 126.94812600645753,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "누구나 사용 가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_28",
+    "statNm": "익명_충전소_28",
+    "addr": "익명_주소",
+    "lat": 37.57662229082302,
+    "lng": 127.0186962872618,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "누구나 사용가능",
+    "note": "누구나 사용가능",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_29",
+    "statNm": "익명_충전소_29",
+    "addr": "익명_주소",
+    "lat": 37.535672960242714,
+    "lng": 127.02234174861462,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_30",
+    "statNm": "익명_충전소_30",
+    "addr": "익명_주소",
+    "lat": 37.53940454539356,
+    "lng": 126.98576969225941,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "누구나 사용 가능",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_31",
+    "statNm": "익명_충전소_31",
+    "addr": "익명_주소",
+    "lat": 37.60801862637347,
+    "lng": 126.99415265781032,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "누구나 사용 가능",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_32",
+    "statNm": "익명_충전소_32",
+    "addr": "익명_주소",
+    "lat": 37.58844877902352,
+    "lng": 127.01582732686701,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "12",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_33",
+    "statNm": "익명_충전소_33",
+    "addr": "익명_주소",
+    "lat": 37.59743070908809,
+    "lng": 126.93065378715377,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "주차 요금 : 10분당 1,000원 / 워터 회원은 급속 충전 시 30분 주차 무료 (B동 로비에서 할인권 수령)",
+    "totalChargers": 10,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "14",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "15",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "16",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_34",
+    "statNm": "익명_충전소_34",
+    "addr": "익명_주소",
+    "lat": 37.5802633131434,
+    "lng": 127.00523167059255,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_35",
+    "statNm": "익명_충전소_35",
+    "addr": "익명_주소",
+    "lat": 37.58006742639367,
+    "lng": 126.93749326899677,
+    "useTime": "24시간 이용가능(직원전용)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "SK에코플랜트 직원만 이용가능",
+    "note": "",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_36",
+    "statNm": "익명_충전소_36",
+    "addr": "익명_주소",
+    "lat": 37.57260416716227,
+    "lng": 127.02530930987436,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "11",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_37",
+    "statNm": "익명_충전소_37",
+    "addr": "익명_주소",
+    "lat": 37.59699238914356,
+    "lng": 127.03241220590091,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따라 주차비가 발생할 수 있음 ",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_38",
+    "statNm": "익명_충전소_38",
+    "addr": "익명_주소",
+    "lat": 37.575942785281484,
+    "lng": 126.92934716877303,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_39",
+    "statNm": "익명_충전소_39",
+    "addr": "익명_주소",
+    "lat": 37.55753377621323,
+    "lng": 126.93001865631487,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "06",
+        "stat": "3",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "06",
+        "stat": "3",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_40",
+    "statNm": "익명_충전소_40",
+    "addr": "익명_주소",
+    "lat": 37.593883860194694,
+    "lng": 126.93852360087918,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_41",
+    "statNm": "익명_충전소_41",
+    "addr": "익명_주소",
+    "lat": 37.56131879718049,
+    "lng": 127.01912150788095,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_42",
+    "statNm": "익명_충전소_42",
+    "addr": "익명_주소",
+    "lat": 37.58998493547734,
+    "lng": 126.982288337605,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_43",
+    "statNm": "익명_충전소_43",
+    "addr": "익명_주소",
+    "lat": 37.53182555803119,
+    "lng": 127.02395637917594,
+    "useTime": "운영시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "관계자 외 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_44",
+    "statNm": "익명_충전소_44",
+    "addr": "익명_주소",
+    "lat": 37.614984182693306,
+    "lng": 126.9874578626103,
+    "useTime": "09:00 ~ 18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_45",
+    "statNm": "익명_충전소_45",
+    "addr": "익명_주소",
+    "lat": 37.5260613529725,
+    "lng": 126.94461226407171,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_46",
+    "statNm": "익명_충전소_46",
+    "addr": "익명_주소",
+    "lat": 37.53627922720887,
+    "lng": 126.94039836939113,
+    "useTime": "09:00 ~ 18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_47",
+    "statNm": "익명_충전소_47",
+    "addr": "익명_주소",
+    "lat": 37.60691457531005,
+    "lng": 126.99222337962792,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_48",
+    "statNm": "익명_충전소_48",
+    "addr": "익명_주소",
+    "lat": 37.560838242479406,
+    "lng": 126.97008162044497,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_49",
+    "statNm": "익명_충전소_49",
+    "addr": "익명_주소",
+    "lat": 37.608728904366586,
+    "lng": 126.94552714555827,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 출입불가",
+    "note": "외부인 출입불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_50",
+    "statNm": "익명_충전소_50",
+    "addr": "익명_주소",
+    "lat": 37.551983056556445,
+    "lng": 127.0202138096486,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_51",
+    "statNm": "익명_충전소_51",
+    "addr": "익명_주소",
+    "lat": 37.53234445341505,
+    "lng": 126.9331974685106,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_52",
+    "statNm": "익명_충전소_52",
+    "addr": "익명_주소",
+    "lat": 37.527480930251286,
+    "lng": 126.9232269281473,
+    "useTime": "외부인 이용불가",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "외부인 이용불가",
+    "note": "외부인 이용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_53",
+    "statNm": "익명_충전소_53",
+    "addr": "익명_주소",
+    "lat": 37.53676216665091,
+    "lng": 126.93491063154872,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_54",
+    "statNm": "익명_충전소_54",
+    "addr": "익명_주소",
+    "lat": 37.54040249081914,
+    "lng": 127.01514236947257,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 13,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_55",
+    "statNm": "익명_충전소_55",
+    "addr": "익명_주소",
+    "lat": 37.55890595998216,
+    "lng": 127.00478383339937,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_56",
+    "statNm": "익명_충전소_56",
+    "addr": "익명_주소",
+    "lat": 37.621259268349256,
+    "lng": 126.93963706615948,
+    "useTime": "06:00 ~ 23:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_57",
+    "statNm": "익명_충전소_57",
+    "addr": "익명_주소",
+    "lat": 37.615191897555384,
+    "lng": 126.96678659890974,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_58",
+    "statNm": "익명_충전소_58",
+    "addr": "익명_주소",
+    "lat": 37.605166136733544,
+    "lng": 126.9555696258438,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_59",
+    "statNm": "익명_충전소_59",
+    "addr": "익명_주소",
+    "lat": 37.60409711728589,
+    "lng": 126.98870140705684,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_60",
+    "statNm": "익명_충전소_60",
+    "addr": "익명_주소",
+    "lat": 37.567904235438036,
+    "lng": 126.95165257538727,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_61",
+    "statNm": "익명_충전소_61",
+    "addr": "익명_주소",
+    "lat": 37.53738523863818,
+    "lng": 126.95556246695895,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 10,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_62",
+    "statNm": "익명_충전소_62",
+    "addr": "익명_주소",
+    "lat": 37.58696850921193,
+    "lng": 126.95571045536008,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_63",
+    "statNm": "익명_충전소_63",
+    "addr": "익명_주소",
+    "lat": 37.587740057173,
+    "lng": 126.99396063952844,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_64",
+    "statNm": "익명_충전소_64",
+    "addr": "익명_주소",
+    "lat": 37.55739467231182,
+    "lng": 127.00639519012591,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_65",
+    "statNm": "익명_충전소_65",
+    "addr": "익명_주소",
+    "lat": 37.55751544549763,
+    "lng": 126.94858455197077,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_66",
+    "statNm": "익명_충전소_66",
+    "addr": "익명_주소",
+    "lat": 37.559057031338604,
+    "lng": 126.91136616266786,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_67",
+    "statNm": "익명_충전소_67",
+    "addr": "익명_주소",
+    "lat": 37.5509538510353,
+    "lng": 126.98084387754083,
+    "useTime": "0000~0000",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_68",
+    "statNm": "익명_충전소_68",
+    "addr": "익명_주소",
+    "lat": 37.50959364725036,
+    "lng": 126.96686162562682,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_69",
+    "statNm": "익명_충전소_69",
+    "addr": "익명_주소",
+    "lat": 37.58336422017792,
+    "lng": 126.93142886235738,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_70",
+    "statNm": "익명_충전소_70",
+    "addr": "익명_주소",
+    "lat": 37.60213206533691,
+    "lng": 126.95124744515745,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_71",
+    "statNm": "익명_충전소_71",
+    "addr": "익명_주소",
+    "lat": 37.56804726663847,
+    "lng": 126.97088789655743,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_72",
+    "statNm": "익명_충전소_72",
+    "addr": "익명_주소",
+    "lat": 37.51984778620445,
+    "lng": 126.97256703554305,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_73",
+    "statNm": "익명_충전소_73",
+    "addr": "익명_주소",
+    "lat": 37.55362124187024,
+    "lng": 127.05237780849376,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_74",
+    "statNm": "익명_충전소_74",
+    "addr": "익명_주소",
+    "lat": 37.594727235461875,
+    "lng": 127.02248787927272,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_75",
+    "statNm": "익명_충전소_75",
+    "addr": "익명_주소",
+    "lat": 37.585258822994824,
+    "lng": 126.98569925245658,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_76",
+    "statNm": "익명_충전소_76",
+    "addr": "익명_주소",
+    "lat": 37.543069849338515,
+    "lng": 127.01588513357146,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "누구나 사용 가능",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_77",
+    "statNm": "익명_충전소_77",
+    "addr": "익명_주소",
+    "lat": 37.543596248250466,
+    "lng": 126.99473331325935,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_78",
+    "statNm": "익명_충전소_78",
+    "addr": "익명_주소",
+    "lat": 37.5876599499178,
+    "lng": 127.00191115667859,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_79",
+    "statNm": "익명_충전소_79",
+    "addr": "익명_주소",
+    "lat": 37.57642478371276,
+    "lng": 126.9651693443967,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "031-778-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_80",
+    "statNm": "익명_충전소_80",
+    "addr": "익명_주소",
+    "lat": 37.605782404217486,
+    "lng": 126.96704769661132,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_81",
+    "statNm": "익명_충전소_81",
+    "addr": "익명_주소",
+    "lat": 37.534292429198594,
+    "lng": 126.96213274234738,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_82",
+    "statNm": "익명_충전소_82",
+    "addr": "익명_주소",
+    "lat": 37.59208406304356,
+    "lng": 127.00576889961692,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_83",
+    "statNm": "익명_충전소_83",
+    "addr": "익명_주소",
+    "lat": 37.5966757630762,
+    "lng": 126.92606767091819,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만이용가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_84",
+    "statNm": "익명_충전소_84",
+    "addr": "익명_주소",
+    "lat": 37.551690585158155,
+    "lng": 127.04316467155965,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 출입불가",
+    "note": "외부인 출입불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_85",
+    "statNm": "익명_충전소_85",
+    "addr": "익명_주소",
+    "lat": 37.538186939440465,
+    "lng": 126.9052956186405,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_86",
+    "statNm": "익명_충전소_86",
+    "addr": "익명_주소",
+    "lat": 37.52895769163606,
+    "lng": 126.98255612490416,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_87",
+    "statNm": "익명_충전소_87",
+    "addr": "익명_주소",
+    "lat": 37.60396665420521,
+    "lng": 126.97464536578285,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_88",
+    "statNm": "익명_충전소_88",
+    "addr": "익명_주소",
+    "lat": 37.621016414085254,
+    "lng": 126.95110350641583,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_89",
+    "statNm": "익명_충전소_89",
+    "addr": "익명_주소",
+    "lat": 37.52032445885343,
+    "lng": 127.00355428692569,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_90",
+    "statNm": "익명_충전소_90",
+    "addr": "익명_주소",
+    "lat": 37.58506921784495,
+    "lng": 126.99545619383622,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_91",
+    "statNm": "익명_충전소_91",
+    "addr": "익명_주소",
+    "lat": 37.566511712899825,
+    "lng": 126.94284405325274,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "버스전용",
+    "note": "버스전용",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 240
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_92",
+    "statNm": "익명_충전소_92",
+    "addr": "익명_주소",
+    "lat": 37.60532901915858,
+    "lng": 127.00093011097053,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "시설 사용자 외 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_93",
+    "statNm": "익명_충전소_93",
+    "addr": "익명_주소",
+    "lat": 37.618656295307275,
+    "lng": 126.99287161432939,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "시설 사용자 외 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_94",
+    "statNm": "익명_충전소_94",
+    "addr": "익명_주소",
+    "lat": 37.58061547720612,
+    "lng": 127.05131468218588,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "누구나 사용 가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_95",
+    "statNm": "익명_충전소_95",
+    "addr": "익명_주소",
+    "lat": 37.62465875964758,
+    "lng": 126.98875885661882,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "시설 상황에 따라 제한 될 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_96",
+    "statNm": "익명_충전소_96",
+    "addr": "익명_주소",
+    "lat": 37.59341129236926,
+    "lng": 127.00211900719526,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 주차비가 발생할 수 있음",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_97",
+    "statNm": "익명_충전소_97",
+    "addr": "익명_주소",
+    "lat": 37.58867262406186,
+    "lng": 126.99043614196799,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_98",
+    "statNm": "익명_충전소_98",
+    "addr": "익명_주소",
+    "lat": 37.538552951306535,
+    "lng": 126.93381679987473,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_99",
+    "statNm": "익명_충전소_99",
+    "addr": "익명_주소",
+    "lat": 37.56860918929071,
+    "lng": 126.94125927122859,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_100",
+    "statNm": "익명_충전소_100",
+    "addr": "익명_주소",
+    "lat": 37.523008343196224,
+    "lng": 126.92750224154912,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_101",
+    "statNm": "익명_충전소_101",
+    "addr": "익명_주소",
+    "lat": 37.57488556276927,
+    "lng": 126.92714744184222,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_102",
+    "statNm": "익명_충전소_102",
+    "addr": "익명_주소",
+    "lat": 37.543816937960585,
+    "lng": 126.94692503640343,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_103",
+    "statNm": "익명_충전소_103",
+    "addr": "익명_주소",
+    "lat": 37.56469129686334,
+    "lng": 126.93996297058554,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_104",
+    "statNm": "익명_충전소_104",
+    "addr": "익명_주소",
+    "lat": 37.519053534521845,
+    "lng": 126.98174660100732,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_105",
+    "statNm": "익명_충전소_105",
+    "addr": "익명_주소",
+    "lat": 37.60684571630756,
+    "lng": 126.99054692883486,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "누구나 사용가능",
+    "note": "누구나 사용 가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_106",
+    "statNm": "익명_충전소_106",
+    "addr": "익명_주소",
+    "lat": 37.60302459997538,
+    "lng": 126.97833231513857,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_107",
+    "statNm": "익명_충전소_107",
+    "addr": "익명_주소",
+    "lat": 37.57206836483821,
+    "lng": 126.90979798102464,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "3",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_108",
+    "statNm": "익명_충전소_108",
+    "addr": "익명_주소",
+    "lat": 37.579804308075836,
+    "lng": 126.95490823016046,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_109",
+    "statNm": "익명_충전소_109",
+    "addr": "익명_주소",
+    "lat": 37.59008219817106,
+    "lng": 127.0107856583561,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_110",
+    "statNm": "익명_충전소_110",
+    "addr": "익명_주소",
+    "lat": 37.618879418175474,
+    "lng": 126.93501703950284,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_111",
+    "statNm": "익명_충전소_111",
+    "addr": "익명_주소",
+    "lat": 37.60642441696806,
+    "lng": 126.98696366623358,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_112",
+    "statNm": "익명_충전소_112",
+    "addr": "익명_주소",
+    "lat": 37.587739194769426,
+    "lng": 126.99834143668977,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_113",
+    "statNm": "익명_충전소_113",
+    "addr": "익명_주소",
+    "lat": 37.519972545110576,
+    "lng": 126.93944370069904,
+    "useTime": "24시간 이용가능(외부인 이용불가)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 이용불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_114",
+    "statNm": "익명_충전소_114",
+    "addr": "익명_주소",
+    "lat": 37.51856475529953,
+    "lng": 127.04542151970665,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "1",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_115",
+    "statNm": "익명_충전소_115",
+    "addr": "익명_주소",
+    "lat": 37.59845220486281,
+    "lng": 126.96619715522054,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_116",
+    "statNm": "익명_충전소_116",
+    "addr": "익명_주소",
+    "lat": 37.57287827537462,
+    "lng": 126.99079383619126,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_117",
+    "statNm": "익명_충전소_117",
+    "addr": "익명_주소",
+    "lat": 37.58425959802772,
+    "lng": 126.959708158742,
+    "useTime": "0000~0000",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_118",
+    "statNm": "익명_충전소_118",
+    "addr": "익명_주소",
+    "lat": 37.59517846116946,
+    "lng": 126.95393128389138,
+    "useTime": "부분개방(07:00~23:00)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_119",
+    "statNm": "익명_충전소_119",
+    "addr": "익명_주소",
+    "lat": 37.5784097779868,
+    "lng": 126.9891882659551,
+    "useTime": "부분개방(07:00~23:00)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "5",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "5",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_120",
+    "statNm": "익명_충전소_120",
+    "addr": "익명_주소",
+    "lat": 37.629542593292626,
+    "lng": 127.01949596183485,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 9,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "06",
+        "stat": "1",
+        "output": 50
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_121",
+    "statNm": "익명_충전소_121",
+    "addr": "익명_주소",
+    "lat": 37.52942143113801,
+    "lng": 126.91464380507243,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 전용",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_122",
+    "statNm": "익명_충전소_122",
+    "addr": "익명_주소",
+    "lat": 37.59659526146525,
+    "lng": 126.99328633169551,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_123",
+    "statNm": "익명_충전소_123",
+    "addr": "익명_주소",
+    "lat": 37.513915681408115,
+    "lng": 126.96164393980557,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_124",
+    "statNm": "익명_충전소_124",
+    "addr": "익명_주소",
+    "lat": 37.544314797971666,
+    "lng": 126.92309648645161,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_125",
+    "statNm": "익명_충전소_125",
+    "addr": "익명_주소",
+    "lat": 37.510870230860434,
+    "lng": 126.95759501767472,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_126",
+    "statNm": "익명_충전소_126",
+    "addr": "익명_주소",
+    "lat": 37.564062828508774,
+    "lng": 126.95144288824609,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "06",
+        "stat": "1",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_127",
+    "statNm": "익명_충전소_127",
+    "addr": "익명_주소",
+    "lat": 37.60207704731042,
+    "lng": 127.03507452518818,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "누구나 사용가능",
+    "note": "누구나 사용 가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_128",
+    "statNm": "익명_충전소_128",
+    "addr": "익명_주소",
+    "lat": 37.52177140266856,
+    "lng": 127.01592139772912,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_129",
+    "statNm": "익명_충전소_129",
+    "addr": "익명_주소",
+    "lat": 37.57980761229083,
+    "lng": 126.96634674578239,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_130",
+    "statNm": "익명_충전소_130",
+    "addr": "익명_주소",
+    "lat": 37.521175187049955,
+    "lng": 126.94198118645443,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_131",
+    "statNm": "익명_충전소_131",
+    "addr": "익명_주소",
+    "lat": 37.59782189175268,
+    "lng": 126.99666678395654,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_132",
+    "statNm": "익명_충전소_132",
+    "addr": "익명_주소",
+    "lat": 37.57146036415587,
+    "lng": 126.94074477671262,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_133",
+    "statNm": "익명_충전소_133",
+    "addr": "익명_주소",
+    "lat": 37.52236608467766,
+    "lng": 126.95587690257159,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_134",
+    "statNm": "익명_충전소_134",
+    "addr": "익명_주소",
+    "lat": 37.57892252095978,
+    "lng": 126.94601421786008,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_135",
+    "statNm": "익명_충전소_135",
+    "addr": "익명_주소",
+    "lat": 37.583771749463985,
+    "lng": 126.98052150528652,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_136",
+    "statNm": "익명_충전소_136",
+    "addr": "익명_주소",
+    "lat": 37.55360447831971,
+    "lng": 126.92940738310756,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_137",
+    "statNm": "익명_충전소_137",
+    "addr": "익명_주소",
+    "lat": 37.53863127102501,
+    "lng": 127.03187610371357,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_138",
+    "statNm": "익명_충전소_138",
+    "addr": "익명_주소",
+    "lat": 37.51808069876233,
+    "lng": 126.95708992381076,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_139",
+    "statNm": "익명_충전소_139",
+    "addr": "익명_주소",
+    "lat": 37.51148131126481,
+    "lng": 126.93468903074654,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_140",
+    "statNm": "익명_충전소_140",
+    "addr": "익명_주소",
+    "lat": 37.55743297584386,
+    "lng": 127.03223737719567,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "시설 사용자 외 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_141",
+    "statNm": "익명_충전소_141",
+    "addr": "익명_주소",
+    "lat": 37.59858237644789,
+    "lng": 126.98314009997013,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_142",
+    "statNm": "익명_충전소_142",
+    "addr": "익명_주소",
+    "lat": 37.60150806734038,
+    "lng": 127.04806073971322,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "24시간 누구나 개방(무료주차) 충전소",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_143",
+    "statNm": "익명_충전소_143",
+    "addr": "익명_주소",
+    "lat": 37.55216005664961,
+    "lng": 126.94419438705216,
+    "useTime": "09:00 ~ 18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_144",
+    "statNm": "익명_충전소_144",
+    "addr": "익명_주소",
+    "lat": 37.55831232197454,
+    "lng": 127.02661568089117,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_145",
+    "statNm": "익명_충전소_145",
+    "addr": "익명_주소",
+    "lat": 37.5756140428082,
+    "lng": 126.97472791696997,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_146",
+    "statNm": "익명_충전소_146",
+    "addr": "익명_주소",
+    "lat": 37.57994355598905,
+    "lng": 126.94470507315741,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_147",
+    "statNm": "익명_충전소_147",
+    "addr": "익명_주소",
+    "lat": 37.57925707963196,
+    "lng": 126.95407135990214,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_148",
+    "statNm": "익명_충전소_148",
+    "addr": "익명_주소",
+    "lat": 37.60328644112863,
+    "lng": 127.00359252798741,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_149",
+    "statNm": "익명_충전소_149",
+    "addr": "익명_주소",
+    "lat": 37.619209561988676,
+    "lng": 127.00049421663107,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_150",
+    "statNm": "익명_충전소_150",
+    "addr": "익명_주소",
+    "lat": 37.58011573995946,
+    "lng": 126.99119299285881,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_151",
+    "statNm": "익명_충전소_151",
+    "addr": "익명_주소",
+    "lat": 37.55165059079117,
+    "lng": 126.96254023145471,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_152",
+    "statNm": "익명_충전소_152",
+    "addr": "익명_주소",
+    "lat": 37.57474920166077,
+    "lng": 126.90920373678492,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_153",
+    "statNm": "익명_충전소_153",
+    "addr": "익명_주소",
+    "lat": 37.55358149604872,
+    "lng": 126.93730549499722,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_154",
+    "statNm": "익명_충전소_154",
+    "addr": "익명_주소",
+    "lat": 37.553500685391974,
+    "lng": 127.01085641696793,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "24시간 이용가능",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_155",
+    "statNm": "익명_충전소_155",
+    "addr": "익명_주소",
+    "lat": 37.55723216432648,
+    "lng": 127.0103879533531,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_156",
+    "statNm": "익명_충전소_156",
+    "addr": "익명_주소",
+    "lat": 37.590623677571344,
+    "lng": 127.00138237563719,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_157",
+    "statNm": "익명_충전소_157",
+    "addr": "익명_주소",
+    "lat": 37.59541680617518,
+    "lng": 126.96918774918205,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_158",
+    "statNm": "익명_충전소_158",
+    "addr": "익명_주소",
+    "lat": 37.596477647904685,
+    "lng": 126.96001185276857,
+    "useTime": "06:00-24:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_159",
+    "statNm": "익명_충전소_159",
+    "addr": "익명_주소",
+    "lat": 37.560852445113035,
+    "lng": 126.96178452209531,
+    "useTime": "24시간 이용가능(입주민 외 이용제한 있을 수 있음)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_160",
+    "statNm": "익명_충전소_160",
+    "addr": "익명_주소",
+    "lat": 37.59676956492901,
+    "lng": 126.93224539409881,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_161",
+    "statNm": "익명_충전소_161",
+    "addr": "익명_주소",
+    "lat": 37.580367120807416,
+    "lng": 126.96983418318942,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용금지",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_162",
+    "statNm": "익명_충전소_162",
+    "addr": "익명_주소",
+    "lat": 37.54665316556973,
+    "lng": 126.96770570252605,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_163",
+    "statNm": "익명_충전소_163",
+    "addr": "익명_주소",
+    "lat": 37.5692367377269,
+    "lng": 127.0070435360926,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "3",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_164",
+    "statNm": "익명_충전소_164",
+    "addr": "익명_주소",
+    "lat": 37.56150065559327,
+    "lng": 127.03278985281827,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_165",
+    "statNm": "익명_충전소_165",
+    "addr": "익명_주소",
+    "lat": 37.57366782297318,
+    "lng": 126.90010247200237,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용금지",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_166",
+    "statNm": "익명_충전소_166",
+    "addr": "익명_주소",
+    "lat": 37.56735567313631,
+    "lng": 126.93867264795902,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용금지",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_167",
+    "statNm": "익명_충전소_167",
+    "addr": "익명_주소",
+    "lat": 37.547267242244644,
+    "lng": 126.95703037633037,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_168",
+    "statNm": "익명_충전소_168",
+    "addr": "익명_주소",
+    "lat": 37.57759503595941,
+    "lng": 126.9808088620786,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 9,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_169",
+    "statNm": "익명_충전소_169",
+    "addr": "익명_주소",
+    "lat": 37.56937190153872,
+    "lng": 126.94215693509364,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_170",
+    "statNm": "익명_충전소_170",
+    "addr": "익명_주소",
+    "lat": 37.52024620545096,
+    "lng": 126.9524245564019,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_171",
+    "statNm": "익명_충전소_171",
+    "addr": "익명_주소",
+    "lat": 37.55891123160879,
+    "lng": 126.915471509601,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_172",
+    "statNm": "익명_충전소_172",
+    "addr": "익명_주소",
+    "lat": 37.572735598114434,
+    "lng": 126.89471168134513,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_173",
+    "statNm": "익명_충전소_173",
+    "addr": "익명_주소",
+    "lat": 37.58807079304554,
+    "lng": 126.91663783077922,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 9,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_174",
+    "statNm": "익명_충전소_174",
+    "addr": "익명_주소",
+    "lat": 37.58201213993245,
+    "lng": 126.95028441499056,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_175",
+    "statNm": "익명_충전소_175",
+    "addr": "익명_주소",
+    "lat": 37.556715626452416,
+    "lng": 126.89576878809726,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_176",
+    "statNm": "익명_충전소_176",
+    "addr": "익명_주소",
+    "lat": 37.54791820499295,
+    "lng": 126.99879255618089,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_177",
+    "statNm": "익명_충전소_177",
+    "addr": "익명_주소",
+    "lat": 37.582815272575836,
+    "lng": 127.02751330608386,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_178",
+    "statNm": "익명_충전소_178",
+    "addr": "익명_주소",
+    "lat": 37.53851357046001,
+    "lng": 126.92238353019145,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_179",
+    "statNm": "익명_충전소_179",
+    "addr": "익명_주소",
+    "lat": 37.52688738167349,
+    "lng": 126.94496246552849,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_180",
+    "statNm": "익명_충전소_180",
+    "addr": "익명_주소",
+    "lat": 37.581231588377584,
+    "lng": 127.06648904134717,
+    "useTime": "0000~0000",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_181",
+    "statNm": "익명_충전소_181",
+    "addr": "익명_주소",
+    "lat": 37.522390495134694,
+    "lng": 126.91357629188468,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_182",
+    "statNm": "익명_충전소_182",
+    "addr": "익명_주소",
+    "lat": 37.57273480779268,
+    "lng": 127.04438028146038,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_183",
+    "statNm": "익명_충전소_183",
+    "addr": "익명_주소",
+    "lat": 37.50275946193931,
+    "lng": 126.94061650513115,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_184",
+    "statNm": "익명_충전소_184",
+    "addr": "익명_주소",
+    "lat": 37.593608659387904,
+    "lng": 126.97642270294921,
+    "useTime": "0000~0000",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_185",
+    "statNm": "익명_충전소_185",
+    "addr": "익명_주소",
+    "lat": 37.54774472913641,
+    "lng": 126.9956497103916,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_186",
+    "statNm": "익명_충전소_186",
+    "addr": "익명_주소",
+    "lat": 37.57744494321234,
+    "lng": 126.9987738329777,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "시설 상황에 따라 제한 될 수 있음",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_187",
+    "statNm": "익명_충전소_187",
+    "addr": "익명_주소",
+    "lat": 37.60470453363582,
+    "lng": 127.00141309020161,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 11,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_188",
+    "statNm": "익명_충전소_188",
+    "addr": "익명_주소",
+    "lat": 37.590208712856025,
+    "lng": 126.93842422387878,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용금지",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_189",
+    "statNm": "익명_충전소_189",
+    "addr": "익명_주소",
+    "lat": 37.588312641757135,
+    "lng": 126.92963514541653,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_190",
+    "statNm": "익명_충전소_190",
+    "addr": "익명_주소",
+    "lat": 37.55360826856829,
+    "lng": 126.91312222180403,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용금지",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_191",
+    "statNm": "익명_충전소_191",
+    "addr": "익명_주소",
+    "lat": 37.54711307475909,
+    "lng": 126.98105285809247,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_192",
+    "statNm": "익명_충전소_192",
+    "addr": "익명_주소",
+    "lat": 37.524507645103355,
+    "lng": 126.89795304011024,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_193",
+    "statNm": "익명_충전소_193",
+    "addr": "익명_주소",
+    "lat": 37.566432691311306,
+    "lng": 126.94697107720017,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_194",
+    "statNm": "익명_충전소_194",
+    "addr": "익명_주소",
+    "lat": 37.497730441291175,
+    "lng": 126.99610806657942,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_195",
+    "statNm": "익명_충전소_195",
+    "addr": "익명_주소",
+    "lat": 37.49276014873015,
+    "lng": 126.94796253414759,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "02-709-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "81",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 350
+      },
+      {
+        "chgerId": "82",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 350
+      },
+      {
+        "chgerId": "83",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 350
+      },
+      {
+        "chgerId": "84",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 350
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_196",
+    "statNm": "익명_충전소_196",
+    "addr": "익명_주소",
+    "lat": 37.53654254097267,
+    "lng": 126.95656203010365,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_197",
+    "statNm": "익명_충전소_197",
+    "addr": "익명_주소",
+    "lat": 37.56234226044225,
+    "lng": 127.01820810818936,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용금지",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_198",
+    "statNm": "익명_충전소_198",
+    "addr": "익명_주소",
+    "lat": 37.584639663417335,
+    "lng": 126.98245455789262,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_199",
+    "statNm": "익명_충전소_199",
+    "addr": "익명_주소",
+    "lat": 37.51203162584505,
+    "lng": 126.95144816919937,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_200",
+    "statNm": "익명_충전소_200",
+    "addr": "익명_주소",
+    "lat": 37.579843718453965,
+    "lng": 127.00363637741712,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 10,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_201",
+    "statNm": "익명_충전소_201",
+    "addr": "익명_주소",
+    "lat": 37.55407142549145,
+    "lng": 126.91659221158743,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_202",
+    "statNm": "익명_충전소_202",
+    "addr": "익명_주소",
+    "lat": 37.56548281879554,
+    "lng": 127.06167332877448,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_203",
+    "statNm": "익명_충전소_203",
+    "addr": "익명_주소",
+    "lat": 37.55470228160152,
+    "lng": 127.02410320792137,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_204",
+    "statNm": "익명_충전소_204",
+    "addr": "익명_주소",
+    "lat": 37.52638646820508,
+    "lng": 126.96524960515254,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_205",
+    "statNm": "익명_충전소_205",
+    "addr": "익명_주소",
+    "lat": 37.500933324638204,
+    "lng": 126.93214841722487,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_206",
+    "statNm": "익명_충전소_206",
+    "addr": "익명_주소",
+    "lat": 37.57729952510636,
+    "lng": 126.99411131605628,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따라 주차비가 발생할 수 있음 ",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_207",
+    "statNm": "익명_충전소_207",
+    "addr": "익명_주소",
+    "lat": 37.56565102638975,
+    "lng": 126.91911464007754,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_208",
+    "statNm": "익명_충전소_208",
+    "addr": "익명_주소",
+    "lat": 37.51185705828789,
+    "lng": 126.98375826969688,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_209",
+    "statNm": "익명_충전소_209",
+    "addr": "익명_주소",
+    "lat": 37.55744697685891,
+    "lng": 126.94306982374101,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용금지",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_210",
+    "statNm": "익명_충전소_210",
+    "addr": "익명_주소",
+    "lat": 37.568985976331156,
+    "lng": 127.0255662105887,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_211",
+    "statNm": "익명_충전소_211",
+    "addr": "익명_주소",
+    "lat": 37.499505504738295,
+    "lng": 126.93418864517614,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_212",
+    "statNm": "익명_충전소_212",
+    "addr": "익명_주소",
+    "lat": 37.55674741313064,
+    "lng": 126.96802995823957,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_213",
+    "statNm": "익명_충전소_213",
+    "addr": "익명_주소",
+    "lat": 37.57975480000139,
+    "lng": 127.0129991108874,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_214",
+    "statNm": "익명_충전소_214",
+    "addr": "익명_주소",
+    "lat": 37.55850005701293,
+    "lng": 126.90974778797563,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_215",
+    "statNm": "익명_충전소_215",
+    "addr": "익명_주소",
+    "lat": 37.53525070012309,
+    "lng": 126.97075347310805,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_216",
+    "statNm": "익명_충전소_216",
+    "addr": "익명_주소",
+    "lat": 37.54548780527263,
+    "lng": 126.91630801361478,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_217",
+    "statNm": "익명_충전소_217",
+    "addr": "익명_주소",
+    "lat": 37.559089918316886,
+    "lng": 126.93799348566358,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_218",
+    "statNm": "익명_충전소_218",
+    "addr": "익명_주소",
+    "lat": 37.55022564620695,
+    "lng": 126.99577475731216,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_219",
+    "statNm": "익명_충전소_219",
+    "addr": "익명_주소",
+    "lat": 37.52518194331324,
+    "lng": 126.91781882314255,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 10,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_220",
+    "statNm": "익명_충전소_220",
+    "addr": "익명_주소",
+    "lat": 37.553302467640144,
+    "lng": 127.04005382463659,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_221",
+    "statNm": "익명_충전소_221",
+    "addr": "익명_주소",
+    "lat": 37.550511445436044,
+    "lng": 126.96834941456662,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_222",
+    "statNm": "익명_충전소_222",
+    "addr": "익명_주소",
+    "lat": 37.50690141375228,
+    "lng": 126.89525806459194,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_223",
+    "statNm": "익명_충전소_223",
+    "addr": "익명_주소",
+    "lat": 37.560078282963794,
+    "lng": 126.9028090898458,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_224",
+    "statNm": "익명_충전소_224",
+    "addr": "익명_주소",
+    "lat": 37.567938753589715,
+    "lng": 126.96535901771507,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_225",
+    "statNm": "익명_충전소_225",
+    "addr": "익명_주소",
+    "lat": 37.57704358357257,
+    "lng": 127.0169176506712,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_226",
+    "statNm": "익명_충전소_226",
+    "addr": "익명_주소",
+    "lat": 37.57983774264532,
+    "lng": 127.06578443100739,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_227",
+    "statNm": "익명_충전소_227",
+    "addr": "익명_주소",
+    "lat": 37.53665607041767,
+    "lng": 126.98212545021204,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_228",
+    "statNm": "익명_충전소_228",
+    "addr": "익명_주소",
+    "lat": 37.545064433621974,
+    "lng": 126.99485168109301,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_229",
+    "statNm": "익명_충전소_229",
+    "addr": "익명_주소",
+    "lat": 37.53799770413639,
+    "lng": 126.97652181066714,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_230",
+    "statNm": "익명_충전소_230",
+    "addr": "익명_주소",
+    "lat": 37.5837610298874,
+    "lng": 126.90950903884381,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_231",
+    "statNm": "익명_충전소_231",
+    "addr": "익명_주소",
+    "lat": 37.551552675163705,
+    "lng": 126.92094135257653,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_232",
+    "statNm": "익명_충전소_232",
+    "addr": "익명_주소",
+    "lat": 37.57612687894572,
+    "lng": 127.02944549153119,
+    "useTime": "24시간 이용가능(시설이용자 외 이용제한 있을 수 있음)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "시설이용자 외 출입제한 할 수 있음",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_233",
+    "statNm": "익명_충전소_233",
+    "addr": "익명_주소",
+    "lat": 37.54000914737179,
+    "lng": 127.0113564130299,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 주차비가 발생할 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_234",
+    "statNm": "익명_충전소_234",
+    "addr": "익명_주소",
+    "lat": 37.55937316624674,
+    "lng": 126.95997510199061,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_235",
+    "statNm": "익명_충전소_235",
+    "addr": "익명_주소",
+    "lat": 37.59498778306599,
+    "lng": 126.99472677652075,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_236",
+    "statNm": "익명_충전소_236",
+    "addr": "익명_주소",
+    "lat": 37.515316293703826,
+    "lng": 127.0269881115518,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_237",
+    "statNm": "익명_충전소_237",
+    "addr": "익명_주소",
+    "lat": 37.5641879022769,
+    "lng": 126.9347961530087,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "02-709-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 36,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "14",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "15",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "16",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "17",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "18",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "19",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "20",
+        "chgerType": "08",
+        "stat": "9",
+        "output": 30
+      },
+      {
+        "chgerId": "21",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "23",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "24",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "25",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "26",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "27",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "28",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "29",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "30",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "31",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "32",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "33",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "34",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "35",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "36",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_238",
+    "statNm": "익명_충전소_238",
+    "addr": "익명_주소",
+    "lat": 37.52516919258745,
+    "lng": 127.05962387500429,
+    "useTime": "0000~0000",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_239",
+    "statNm": "익명_충전소_239",
+    "addr": "익명_주소",
+    "lat": 37.496728610733754,
+    "lng": 126.97142875389021,
+    "useTime": "09:00~21:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "외부인 출입불가",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "05",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "05",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_240",
+    "statNm": "익명_충전소_240",
+    "addr": "익명_주소",
+    "lat": 37.52130171584307,
+    "lng": 126.9594488141494,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_241",
+    "statNm": "익명_충전소_241",
+    "addr": "익명_주소",
+    "lat": 37.52559424822292,
+    "lng": 126.98000638836793,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_242",
+    "statNm": "익명_충전소_242",
+    "addr": "익명_주소",
+    "lat": 37.58616625333673,
+    "lng": 126.91768023781529,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_243",
+    "statNm": "익명_충전소_243",
+    "addr": "익명_주소",
+    "lat": 37.566599905991794,
+    "lng": 126.97923910625211,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_244",
+    "statNm": "익명_충전소_244",
+    "addr": "익명_주소",
+    "lat": 37.605607863417106,
+    "lng": 127.07274950900879,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_245",
+    "statNm": "익명_충전소_245",
+    "addr": "익명_주소",
+    "lat": 37.55286144872161,
+    "lng": 126.98402574311773,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_246",
+    "statNm": "익명_충전소_246",
+    "addr": "익명_주소",
+    "lat": 37.61534215267106,
+    "lng": 126.99174502658546,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_247",
+    "statNm": "익명_충전소_247",
+    "addr": "익명_주소",
+    "lat": 37.58409039808062,
+    "lng": 127.0235103606186,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_248",
+    "statNm": "익명_충전소_248",
+    "addr": "익명_주소",
+    "lat": 37.56306583159772,
+    "lng": 127.01825770314673,
+    "useTime": "0000~0000",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_249",
+    "statNm": "익명_충전소_249",
+    "addr": "익명_주소",
+    "lat": 37.560971250470594,
+    "lng": 126.97659934959655,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_250",
+    "statNm": "익명_충전소_250",
+    "addr": "익명_주소",
+    "lat": 37.52740481076,
+    "lng": 127.0651236289413,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_251",
+    "statNm": "익명_충전소_251",
+    "addr": "익명_주소",
+    "lat": 37.57039491125706,
+    "lng": 127.04312971725669,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_252",
+    "statNm": "익명_충전소_252",
+    "addr": "익명_주소",
+    "lat": 37.58287590166098,
+    "lng": 127.05139257332073,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_253",
+    "statNm": "익명_충전소_253",
+    "addr": "익명_주소",
+    "lat": 37.55549181062544,
+    "lng": 127.04698525268635,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_254",
+    "statNm": "익명_충전소_254",
+    "addr": "익명_주소",
+    "lat": 37.550573207423376,
+    "lng": 127.01435626061867,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "06",
+        "stat": "3",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_255",
+    "statNm": "익명_충전소_255",
+    "addr": "익명_주소",
+    "lat": 37.597435155203335,
+    "lng": 126.9812645534401,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_256",
+    "statNm": "익명_충전소_256",
+    "addr": "익명_주소",
+    "lat": 37.502510719269225,
+    "lng": 126.98707532107586,
+    "useTime": "외부인 출입금지",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 출입/사용불가 이용제한",
+    "note": "외부인 출입/사용불가 이용제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_257",
+    "statNm": "익명_충전소_257",
+    "addr": "익명_주소",
+    "lat": 37.55181155912786,
+    "lng": 127.02556434607897,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_258",
+    "statNm": "익명_충전소_258",
+    "addr": "익명_주소",
+    "lat": 37.54532203272638,
+    "lng": 126.97632393126851,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_259",
+    "statNm": "익명_충전소_259",
+    "addr": "익명_주소",
+    "lat": 37.57471085032107,
+    "lng": 127.06750459366576,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_260",
+    "statNm": "익명_충전소_260",
+    "addr": "익명_주소",
+    "lat": 37.57449799284539,
+    "lng": 126.89874257628831,
+    "useTime": "평일 09:00~22:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따라 주차비가 발생할 수 있음 ",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_261",
+    "statNm": "익명_충전소_261",
+    "addr": "익명_주소",
+    "lat": 37.58432081406776,
+    "lng": 126.9903047651622,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_262",
+    "statNm": "익명_충전소_262",
+    "addr": "익명_주소",
+    "lat": 37.62442192299742,
+    "lng": 127.00453778552635,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_263",
+    "statNm": "익명_충전소_263",
+    "addr": "익명_주소",
+    "lat": 37.581466317208154,
+    "lng": 126.96222421156169,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_264",
+    "statNm": "익명_충전소_264",
+    "addr": "익명_주소",
+    "lat": 37.58671507046695,
+    "lng": 127.05568769552357,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_265",
+    "statNm": "익명_충전소_265",
+    "addr": "익명_주소",
+    "lat": 37.618053651086555,
+    "lng": 126.96326749965739,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_266",
+    "statNm": "익명_충전소_266",
+    "addr": "익명_주소",
+    "lat": 37.557709351114184,
+    "lng": 126.91700240158598,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_267",
+    "statNm": "익명_충전소_267",
+    "addr": "익명_주소",
+    "lat": 37.55765973223835,
+    "lng": 127.00464215999504,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_268",
+    "statNm": "익명_충전소_268",
+    "addr": "익명_주소",
+    "lat": 37.50183682525411,
+    "lng": 126.9466964795012,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_269",
+    "statNm": "익명_충전소_269",
+    "addr": "익명_주소",
+    "lat": 37.532754479835674,
+    "lng": 127.01456736485753,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_270",
+    "statNm": "익명_충전소_270",
+    "addr": "익명_주소",
+    "lat": 37.57333332563189,
+    "lng": 127.0032703202646,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_271",
+    "statNm": "익명_충전소_271",
+    "addr": "익명_주소",
+    "lat": 37.55677138021038,
+    "lng": 126.95708559818755,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_272",
+    "statNm": "익명_충전소_272",
+    "addr": "익명_주소",
+    "lat": 37.529873624883365,
+    "lng": 126.98128167991399,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_273",
+    "statNm": "익명_충전소_273",
+    "addr": "익명_주소",
+    "lat": 37.52942041298434,
+    "lng": 126.9936713416325,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_274",
+    "statNm": "익명_충전소_274",
+    "addr": "익명_주소",
+    "lat": 37.51799388537853,
+    "lng": 127.01554189192696,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_275",
+    "statNm": "익명_충전소_275",
+    "addr": "익명_주소",
+    "lat": 37.576342818538244,
+    "lng": 126.96615846737967,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_276",
+    "statNm": "익명_충전소_276",
+    "addr": "익명_주소",
+    "lat": 37.60615546103111,
+    "lng": 127.00574625012102,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_277",
+    "statNm": "익명_충전소_277",
+    "addr": "익명_주소",
+    "lat": 37.5858296560972,
+    "lng": 127.00827748293099,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_278",
+    "statNm": "익명_충전소_278",
+    "addr": "익명_주소",
+    "lat": 37.546210281692865,
+    "lng": 126.96281280991944,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_279",
+    "statNm": "익명_충전소_279",
+    "addr": "익명_주소",
+    "lat": 37.556914905185295,
+    "lng": 126.9127364594376,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_280",
+    "statNm": "익명_충전소_280",
+    "addr": "익명_주소",
+    "lat": 37.57484006944116,
+    "lng": 127.05866161767648,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_281",
+    "statNm": "익명_충전소_281",
+    "addr": "익명_주소",
+    "lat": 37.58771683432687,
+    "lng": 126.98851287000095,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_282",
+    "statNm": "익명_충전소_282",
+    "addr": "익명_주소",
+    "lat": 37.58780621657637,
+    "lng": 126.95786846179398,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 10,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_283",
+    "statNm": "익명_충전소_283",
+    "addr": "익명_주소",
+    "lat": 37.55042761917782,
+    "lng": 127.01568723036577,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_284",
+    "statNm": "익명_충전소_284",
+    "addr": "익명_주소",
+    "lat": 37.60727320478898,
+    "lng": 127.07438703629145,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_285",
+    "statNm": "익명_충전소_285",
+    "addr": "익명_주소",
+    "lat": 37.529358073130275,
+    "lng": 126.9779372966029,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_286",
+    "statNm": "익명_충전소_286",
+    "addr": "익명_주소",
+    "lat": 37.60426994027075,
+    "lng": 126.99685009362904,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_287",
+    "statNm": "익명_충전소_287",
+    "addr": "익명_주소",
+    "lat": 37.58156737063093,
+    "lng": 127.0264833012019,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_288",
+    "statNm": "익명_충전소_288",
+    "addr": "익명_주소",
+    "lat": 37.57533842791092,
+    "lng": 127.04041769297797,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_289",
+    "statNm": "익명_충전소_289",
+    "addr": "익명_주소",
+    "lat": 37.595855602499796,
+    "lng": 126.89991573063914,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_290",
+    "statNm": "익명_충전소_290",
+    "addr": "익명_주소",
+    "lat": 37.50579377370588,
+    "lng": 127.00550610319347,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_291",
+    "statNm": "익명_충전소_291",
+    "addr": "익명_주소",
+    "lat": 37.571683083732374,
+    "lng": 126.99327868411501,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "시민개방충전소",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_292",
+    "statNm": "익명_충전소_292",
+    "addr": "익명_주소",
+    "lat": 37.587458300559334,
+    "lng": 126.95499185152178,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_293",
+    "statNm": "익명_충전소_293",
+    "addr": "익명_주소",
+    "lat": 37.6207126695755,
+    "lng": 127.05336945473074,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따란 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_294",
+    "statNm": "익명_충전소_294",
+    "addr": "익명_주소",
+    "lat": 37.595765858719474,
+    "lng": 127.01287990503384,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "거주자 외 출입제한",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_295",
+    "statNm": "익명_충전소_295",
+    "addr": "익명_주소",
+    "lat": 37.561599915088976,
+    "lng": 126.89469937661228,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_296",
+    "statNm": "익명_충전소_296",
+    "addr": "익명_주소",
+    "lat": 37.556453623513676,
+    "lng": 126.91542841620188,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_297",
+    "statNm": "익명_충전소_297",
+    "addr": "익명_주소",
+    "lat": 37.584033589434824,
+    "lng": 126.96890043155152,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_298",
+    "statNm": "익명_충전소_298",
+    "addr": "익명_주소",
+    "lat": 37.58405037975015,
+    "lng": 126.98791922877027,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_299",
+    "statNm": "익명_충전소_299",
+    "addr": "익명_주소",
+    "lat": 37.579398267631476,
+    "lng": 126.95263040731248,
+    "useTime": "08:00~24:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "주차요금 30분 무료/추가 10분당 1000원 충전기이용시2시간무료",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_300",
+    "statNm": "익명_충전소_300",
+    "addr": "익명_주소",
+    "lat": 37.59433290693042,
+    "lng": 126.97038277919367,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_301",
+    "statNm": "익명_충전소_301",
+    "addr": "익명_주소",
+    "lat": 37.56360795239457,
+    "lng": 126.9970473173828,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "거주자 외 출입제한",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_302",
+    "statNm": "익명_충전소_302",
+    "addr": "익명_주소",
+    "lat": 37.601016028169006,
+    "lng": 126.95365797118284,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_303",
+    "statNm": "익명_충전소_303",
+    "addr": "익명_주소",
+    "lat": 37.5405590098677,
+    "lng": 126.93103457634946,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_304",
+    "statNm": "익명_충전소_304",
+    "addr": "익명_주소",
+    "lat": 37.54080196606612,
+    "lng": 126.97942298028433,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 9,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_305",
+    "statNm": "익명_충전소_305",
+    "addr": "익명_주소",
+    "lat": 37.51212705622855,
+    "lng": 126.94784898963995,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_306",
+    "statNm": "익명_충전소_306",
+    "addr": "익명_주소",
+    "lat": 37.5949140340309,
+    "lng": 126.97163062351747,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_307",
+    "statNm": "익명_충전소_307",
+    "addr": "익명_주소",
+    "lat": 37.5335877991513,
+    "lng": 126.94621188568962,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_308",
+    "statNm": "익명_충전소_308",
+    "addr": "익명_주소",
+    "lat": 37.53662311053903,
+    "lng": 126.9810894463339,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_309",
+    "statNm": "익명_충전소_309",
+    "addr": "익명_주소",
+    "lat": 37.58067995797594,
+    "lng": 126.95617478920474,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_310",
+    "statNm": "익명_충전소_310",
+    "addr": "익명_주소",
+    "lat": 37.58082480345301,
+    "lng": 126.99808843396836,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_311",
+    "statNm": "익명_충전소_311",
+    "addr": "익명_주소",
+    "lat": 37.590433387099516,
+    "lng": 126.97684586231331,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_312",
+    "statNm": "익명_충전소_312",
+    "addr": "익명_주소",
+    "lat": 37.52639466078923,
+    "lng": 126.95578467281044,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_313",
+    "statNm": "익명_충전소_313",
+    "addr": "익명_주소",
+    "lat": 37.58550373246214,
+    "lng": 126.9805416562684,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "4",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_314",
+    "statNm": "익명_충전소_314",
+    "addr": "익명_주소",
+    "lat": 37.52625324867515,
+    "lng": 127.01131507516435,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_315",
+    "statNm": "익명_충전소_315",
+    "addr": "익명_주소",
+    "lat": 37.57544473216003,
+    "lng": 126.9374400389642,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "주차요금 30분 무료/추가 10분당 1000원 충전기이용시2시간무료",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_316",
+    "statNm": "익명_충전소_316",
+    "addr": "익명_주소",
+    "lat": 37.51241468225135,
+    "lng": 126.96826000122911,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_317",
+    "statNm": "익명_충전소_317",
+    "addr": "익명_주소",
+    "lat": 37.51382282361775,
+    "lng": 126.96277104533162,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_318",
+    "statNm": "익명_충전소_318",
+    "addr": "익명_주소",
+    "lat": 37.597023162131585,
+    "lng": 126.96854758421769,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_319",
+    "statNm": "익명_충전소_319",
+    "addr": "익명_주소",
+    "lat": 37.53850218588568,
+    "lng": 126.97635032064609,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_320",
+    "statNm": "익명_충전소_320",
+    "addr": "익명_주소",
+    "lat": 37.63241469859424,
+    "lng": 127.05436339716861,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_321",
+    "statNm": "익명_충전소_321",
+    "addr": "익명_주소",
+    "lat": 37.54914345853309,
+    "lng": 126.9063945682303,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_322",
+    "statNm": "익명_충전소_322",
+    "addr": "익명_주소",
+    "lat": 37.54196188164777,
+    "lng": 126.91985109600223,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_323",
+    "statNm": "익명_충전소_323",
+    "addr": "익명_주소",
+    "lat": 37.59455517279891,
+    "lng": 127.01984767838259,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_324",
+    "statNm": "익명_충전소_324",
+    "addr": "익명_주소",
+    "lat": 37.57934187489036,
+    "lng": 127.04945842996356,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_325",
+    "statNm": "익명_충전소_325",
+    "addr": "익명_주소",
+    "lat": 37.59180709234502,
+    "lng": 126.97886389969587,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_326",
+    "statNm": "익명_충전소_326",
+    "addr": "익명_주소",
+    "lat": 37.56890223625502,
+    "lng": 127.01656339091346,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_327",
+    "statNm": "익명_충전소_327",
+    "addr": "익명_주소",
+    "lat": 37.53413346435552,
+    "lng": 127.00706715641226,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_328",
+    "statNm": "익명_충전소_328",
+    "addr": "익명_주소",
+    "lat": 37.52638690368982,
+    "lng": 127.01961641242929,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_329",
+    "statNm": "익명_충전소_329",
+    "addr": "익명_주소",
+    "lat": 37.539204111522366,
+    "lng": 126.99655459996256,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_330",
+    "statNm": "익명_충전소_330",
+    "addr": "익명_주소",
+    "lat": 37.60241678466173,
+    "lng": 127.01663712423289,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_331",
+    "statNm": "익명_충전소_331",
+    "addr": "익명_주소",
+    "lat": 37.567999610318324,
+    "lng": 126.96760845636064,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_332",
+    "statNm": "익명_충전소_332",
+    "addr": "익명_주소",
+    "lat": 37.565856458466456,
+    "lng": 126.94168052311358,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_333",
+    "statNm": "익명_충전소_333",
+    "addr": "익명_주소",
+    "lat": 37.62895215171846,
+    "lng": 126.99594902093408,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_334",
+    "statNm": "익명_충전소_334",
+    "addr": "익명_주소",
+    "lat": 37.52018664631842,
+    "lng": 126.97336708295882,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_335",
+    "statNm": "익명_충전소_335",
+    "addr": "익명_주소",
+    "lat": 37.56134195376221,
+    "lng": 127.01707570403227,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_336",
+    "statNm": "익명_충전소_336",
+    "addr": "익명_주소",
+    "lat": 37.504311944737346,
+    "lng": 126.93591106089409,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_337",
+    "statNm": "익명_충전소_337",
+    "addr": "익명_주소",
+    "lat": 37.55688895336531,
+    "lng": 127.01355832166773,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_338",
+    "statNm": "익명_충전소_338",
+    "addr": "익명_주소",
+    "lat": 37.599260473188465,
+    "lng": 127.07466463168545,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_339",
+    "statNm": "익명_충전소_339",
+    "addr": "익명_주소",
+    "lat": 37.49110342903132,
+    "lng": 126.96111989747654,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_340",
+    "statNm": "익명_충전소_340",
+    "addr": "익명_주소",
+    "lat": 37.60450474907097,
+    "lng": 126.97078816976214,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_341",
+    "statNm": "익명_충전소_341",
+    "addr": "익명_주소",
+    "lat": 37.55713627797562,
+    "lng": 127.03483435237919,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_342",
+    "statNm": "익명_충전소_342",
+    "addr": "익명_주소",
+    "lat": 37.54961563634413,
+    "lng": 127.04841108063974,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_343",
+    "statNm": "익명_충전소_343",
+    "addr": "익명_주소",
+    "lat": 37.54550395439738,
+    "lng": 126.91865919543216,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_344",
+    "statNm": "익명_충전소_344",
+    "addr": "익명_주소",
+    "lat": 37.56356130590513,
+    "lng": 127.00546059899239,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_345",
+    "statNm": "익명_충전소_345",
+    "addr": "익명_주소",
+    "lat": 37.56080931501581,
+    "lng": 127.04660918364856,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_346",
+    "statNm": "익명_충전소_346",
+    "addr": "익명_주소",
+    "lat": 37.63000308229361,
+    "lng": 127.06566290995393,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_347",
+    "statNm": "익명_충전소_347",
+    "addr": "익명_주소",
+    "lat": 37.54406669542632,
+    "lng": 126.99482400792269,
+    "useTime": "평일 09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따라 주차비가 발생할 수 있음 ",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_348",
+    "statNm": "익명_충전소_348",
+    "addr": "익명_주소",
+    "lat": 37.608836060791276,
+    "lng": 126.97573582132435,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_349",
+    "statNm": "익명_충전소_349",
+    "addr": "익명_주소",
+    "lat": 37.590538723041526,
+    "lng": 126.97304482555673,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_350",
+    "statNm": "익명_충전소_350",
+    "addr": "익명_주소",
+    "lat": 37.57882037138425,
+    "lng": 127.00424781765209,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_351",
+    "statNm": "익명_충전소_351",
+    "addr": "익명_주소",
+    "lat": 37.58680507943285,
+    "lng": 126.99469052176234,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_352",
+    "statNm": "익명_충전소_352",
+    "addr": "익명_주소",
+    "lat": 37.551399405745386,
+    "lng": 126.94126443805929,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "1",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "1",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_353",
+    "statNm": "익명_충전소_353",
+    "addr": "익명_주소",
+    "lat": 37.58148310508481,
+    "lng": 127.043569266951,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_354",
+    "statNm": "익명_충전소_354",
+    "addr": "익명_주소",
+    "lat": 37.549811124943766,
+    "lng": 126.93145413662964,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1899-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_355",
+    "statNm": "익명_충전소_355",
+    "addr": "익명_주소",
+    "lat": 37.49103328630926,
+    "lng": 126.97032055633872,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_356",
+    "statNm": "익명_충전소_356",
+    "addr": "익명_주소",
+    "lat": 37.514421611490036,
+    "lng": 126.91627812272992,
+    "useTime": "24시간 이용가능 (외부인 이용불가)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 이용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_357",
+    "statNm": "익명_충전소_357",
+    "addr": "익명_주소",
+    "lat": 37.48584563922879,
+    "lng": 126.97597880608458,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_358",
+    "statNm": "익명_충전소_358",
+    "addr": "익명_주소",
+    "lat": 37.567979770001735,
+    "lng": 126.97704337335954,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "031-778-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_359",
+    "statNm": "익명_충전소_359",
+    "addr": "익명_주소",
+    "lat": 37.54009543581726,
+    "lng": 126.96715321299983,
+    "useTime": "평일 09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따라 주차비가 발생할 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_360",
+    "statNm": "익명_충전소_360",
+    "addr": "익명_주소",
+    "lat": 37.55002698221189,
+    "lng": 127.07968343936487,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_361",
+    "statNm": "익명_충전소_361",
+    "addr": "익명_주소",
+    "lat": 37.5622645262422,
+    "lng": 126.99309659464215,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_362",
+    "statNm": "익명_충전소_362",
+    "addr": "익명_주소",
+    "lat": 37.59450571562485,
+    "lng": 127.02273530415306,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "01",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_363",
+    "statNm": "익명_충전소_363",
+    "addr": "익명_주소",
+    "lat": 37.56626283002302,
+    "lng": 126.88687551051895,
+    "useTime": "09:00~21:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "08",
+        "stat": "3",
+        "output": 30
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_364",
+    "statNm": "익명_충전소_364",
+    "addr": "익명_주소",
+    "lat": 37.5057673506103,
+    "lng": 126.9822826599607,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_365",
+    "statNm": "익명_충전소_365",
+    "addr": "익명_주소",
+    "lat": 37.53348762024726,
+    "lng": 126.97785846215838,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_366",
+    "statNm": "익명_충전소_366",
+    "addr": "익명_주소",
+    "lat": 37.51028387307859,
+    "lng": 127.00513771368648,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_367",
+    "statNm": "익명_충전소_367",
+    "addr": "익명_주소",
+    "lat": 37.5312238730971,
+    "lng": 126.97472160269197,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_368",
+    "statNm": "익명_충전소_368",
+    "addr": "익명_주소",
+    "lat": 37.53035023522108,
+    "lng": 127.04471435811874,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_369",
+    "statNm": "익명_충전소_369",
+    "addr": "익명_주소",
+    "lat": 37.56722115185209,
+    "lng": 127.04632613642417,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_370",
+    "statNm": "익명_충전소_370",
+    "addr": "익명_주소",
+    "lat": 37.58527467616777,
+    "lng": 127.01669168313865,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_371",
+    "statNm": "익명_충전소_371",
+    "addr": "익명_주소",
+    "lat": 37.50620621274223,
+    "lng": 127.02361110534396,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 출입불가",
+    "note": "외부인 출입불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_372",
+    "statNm": "익명_충전소_372",
+    "addr": "익명_주소",
+    "lat": 37.5753208091695,
+    "lng": 126.90288058982448,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 전용",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_373",
+    "statNm": "익명_충전소_373",
+    "addr": "익명_주소",
+    "lat": 37.50474301566831,
+    "lng": 126.91643164743527,
+    "useTime": "24시간 이용가능 (외부인 이용불가)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_374",
+    "statNm": "익명_충전소_374",
+    "addr": "익명_주소",
+    "lat": 37.582213770779546,
+    "lng": 127.0203074847417,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_375",
+    "statNm": "익명_충전소_375",
+    "addr": "익명_주소",
+    "lat": 37.52823542968504,
+    "lng": 126.97459448369105,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_376",
+    "statNm": "익명_충전소_376",
+    "addr": "익명_주소",
+    "lat": 37.521141329414355,
+    "lng": 126.98268257961286,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 출입불가",
+    "note": "외부인 출입불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_377",
+    "statNm": "익명_충전소_377",
+    "addr": "익명_주소",
+    "lat": 37.52152555698552,
+    "lng": 127.00445098935155,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_378",
+    "statNm": "익명_충전소_378",
+    "addr": "익명_주소",
+    "lat": 37.57838410141249,
+    "lng": 127.03648410171571,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_379",
+    "statNm": "익명_충전소_379",
+    "addr": "익명_주소",
+    "lat": 37.5011688529826,
+    "lng": 127.04321361310045,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_380",
+    "statNm": "익명_충전소_380",
+    "addr": "익명_주소",
+    "lat": 37.61919969479275,
+    "lng": 126.97758041549399,
+    "useTime": "0000~0000",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_381",
+    "statNm": "익명_충전소_381",
+    "addr": "익명_주소",
+    "lat": 37.57632005937231,
+    "lng": 126.88594348190207,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_382",
+    "statNm": "익명_충전소_382",
+    "addr": "익명_주소",
+    "lat": 37.51227813733545,
+    "lng": 126.97056815497972,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_383",
+    "statNm": "익명_충전소_383",
+    "addr": "익명_주소",
+    "lat": 37.50499788390957,
+    "lng": 126.94111785442009,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_384",
+    "statNm": "익명_충전소_384",
+    "addr": "익명_주소",
+    "lat": 37.50728268483499,
+    "lng": 127.03256516088997,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_385",
+    "statNm": "익명_충전소_385",
+    "addr": "익명_주소",
+    "lat": 37.58497935401625,
+    "lng": 126.90901068286895,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_386",
+    "statNm": "익명_충전소_386",
+    "addr": "익명_주소",
+    "lat": 37.56181774386712,
+    "lng": 126.97717588969226,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_387",
+    "statNm": "익명_충전소_387",
+    "addr": "익명_주소",
+    "lat": 37.52727481409748,
+    "lng": 126.98553976193256,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_388",
+    "statNm": "익명_충전소_388",
+    "addr": "익명_주소",
+    "lat": 37.56858099657731,
+    "lng": 126.95241121505214,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_389",
+    "statNm": "익명_충전소_389",
+    "addr": "익명_주소",
+    "lat": 37.54738931555411,
+    "lng": 127.032874477048,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_390",
+    "statNm": "익명_충전소_390",
+    "addr": "익명_주소",
+    "lat": 37.57266077898697,
+    "lng": 127.07434108439386,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_391",
+    "statNm": "익명_충전소_391",
+    "addr": "익명_주소",
+    "lat": 37.51672843818266,
+    "lng": 126.93330569380878,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_392",
+    "statNm": "익명_충전소_392",
+    "addr": "익명_주소",
+    "lat": 37.57544527357414,
+    "lng": 126.97423132451738,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_393",
+    "statNm": "익명_충전소_393",
+    "addr": "익명_주소",
+    "lat": 37.56537294084343,
+    "lng": 127.061587357239,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_394",
+    "statNm": "익명_충전소_394",
+    "addr": "익명_주소",
+    "lat": 37.58431460468215,
+    "lng": 127.0077999938977,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_395",
+    "statNm": "익명_충전소_395",
+    "addr": "익명_주소",
+    "lat": 37.522534626771225,
+    "lng": 126.91697361467428,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_396",
+    "statNm": "익명_충전소_396",
+    "addr": "익명_주소",
+    "lat": 37.567389884337445,
+    "lng": 126.96651818704422,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_397",
+    "statNm": "익명_충전소_397",
+    "addr": "익명_주소",
+    "lat": 37.520770847650425,
+    "lng": 126.97993050100702,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_398",
+    "statNm": "익명_충전소_398",
+    "addr": "익명_주소",
+    "lat": 37.517190204705095,
+    "lng": 126.95615579310419,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_399",
+    "statNm": "익명_충전소_399",
+    "addr": "익명_주소",
+    "lat": 37.550259917051726,
+    "lng": 126.97387595980628,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_400",
+    "statNm": "익명_충전소_400",
+    "addr": "익명_주소",
+    "lat": 37.5490799064693,
+    "lng": 126.9775997005939,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 출입불가",
+    "note": "외부인 출입불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_401",
+    "statNm": "익명_충전소_401",
+    "addr": "익명_주소",
+    "lat": 37.57256525605485,
+    "lng": 126.89578354377133,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_402",
+    "statNm": "익명_충전소_402",
+    "addr": "익명_주소",
+    "lat": 37.53692819368692,
+    "lng": 127.02846663015944,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_403",
+    "statNm": "익명_충전소_403",
+    "addr": "익명_주소",
+    "lat": 37.54068527813662,
+    "lng": 127.0147607116865,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_404",
+    "statNm": "익명_충전소_404",
+    "addr": "익명_주소",
+    "lat": 37.601006502456116,
+    "lng": 126.95497680743155,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_405",
+    "statNm": "익명_충전소_405",
+    "addr": "익명_주소",
+    "lat": 37.582866272885255,
+    "lng": 126.98871452913878,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_406",
+    "statNm": "익명_충전소_406",
+    "addr": "익명_주소",
+    "lat": 37.542560375040296,
+    "lng": 126.95919077862514,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_407",
+    "statNm": "익명_충전소_407",
+    "addr": "익명_주소",
+    "lat": 37.618122306782375,
+    "lng": 126.87490535887348,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_408",
+    "statNm": "익명_충전소_408",
+    "addr": "익명_주소",
+    "lat": 37.50870799648434,
+    "lng": 126.89396683779158,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_409",
+    "statNm": "익명_충전소_409",
+    "addr": "익명_주소",
+    "lat": 37.515158646189214,
+    "lng": 126.91127842211307,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_410",
+    "statNm": "익명_충전소_410",
+    "addr": "익명_주소",
+    "lat": 37.591504163585974,
+    "lng": 127.05232560962692,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_411",
+    "statNm": "익명_충전소_411",
+    "addr": "익명_주소",
+    "lat": 37.589322419331566,
+    "lng": 127.05057916393272,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_412",
+    "statNm": "익명_충전소_412",
+    "addr": "익명_주소",
+    "lat": 37.56787798370405,
+    "lng": 126.92778278767318,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "누구나 사용 가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_413",
+    "statNm": "익명_충전소_413",
+    "addr": "익명_주소",
+    "lat": 37.56364081897895,
+    "lng": 126.99221803122657,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_414",
+    "statNm": "익명_충전소_414",
+    "addr": "익명_주소",
+    "lat": 37.55898631433453,
+    "lng": 126.91743337229242,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_415",
+    "statNm": "익명_충전소_415",
+    "addr": "익명_주소",
+    "lat": 37.53794398936777,
+    "lng": 126.94940140576412,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_416",
+    "statNm": "익명_충전소_416",
+    "addr": "익명_주소",
+    "lat": 37.56900196584415,
+    "lng": 126.97255454215063,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_417",
+    "statNm": "익명_충전소_417",
+    "addr": "익명_주소",
+    "lat": 37.51969025509103,
+    "lng": 126.91427686468923,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_418",
+    "statNm": "익명_충전소_418",
+    "addr": "익명_주소",
+    "lat": 37.49262326230872,
+    "lng": 126.98426275758067,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_419",
+    "statNm": "익명_충전소_419",
+    "addr": "익명_주소",
+    "lat": 37.55999998962117,
+    "lng": 126.90449171978462,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_420",
+    "statNm": "익명_충전소_420",
+    "addr": "익명_주소",
+    "lat": 37.54007706173807,
+    "lng": 126.96605276082622,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_421",
+    "statNm": "익명_충전소_421",
+    "addr": "익명_주소",
+    "lat": 37.5237546696024,
+    "lng": 126.91020917880145,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_422",
+    "statNm": "익명_충전소_422",
+    "addr": "익명_주소",
+    "lat": 37.54348686750014,
+    "lng": 127.02730973638843,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_423",
+    "statNm": "익명_충전소_423",
+    "addr": "익명_주소",
+    "lat": 37.54254875523481,
+    "lng": 127.02576495201183,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "21",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_424",
+    "statNm": "익명_충전소_424",
+    "addr": "익명_주소",
+    "lat": 37.56782838171923,
+    "lng": 127.04799556577404,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_425",
+    "statNm": "익명_충전소_425",
+    "addr": "익명_주소",
+    "lat": 37.53043181871843,
+    "lng": 126.99728855925763,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "거주자외 출입제한",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_426",
+    "statNm": "익명_충전소_426",
+    "addr": "익명_주소",
+    "lat": 37.548257629940316,
+    "lng": 127.00637766522803,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "거주자외 출입제한",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_427",
+    "statNm": "익명_충전소_427",
+    "addr": "익명_주소",
+    "lat": 37.53306197021193,
+    "lng": 126.98609531537043,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_428",
+    "statNm": "익명_충전소_428",
+    "addr": "익명_주소",
+    "lat": 37.4957025775779,
+    "lng": 127.04883927022166,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_429",
+    "statNm": "익명_충전소_429",
+    "addr": "익명_주소",
+    "lat": 37.59386316879729,
+    "lng": 127.04124166606067,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_430",
+    "statNm": "익명_충전소_430",
+    "addr": "익명_주소",
+    "lat": 37.584761715239175,
+    "lng": 127.06769799140221,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_431",
+    "statNm": "익명_충전소_431",
+    "addr": "익명_주소",
+    "lat": 37.562401032357045,
+    "lng": 126.99164411392405,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_432",
+    "statNm": "익명_충전소_432",
+    "addr": "익명_주소",
+    "lat": 37.590837994568446,
+    "lng": 127.03119633400156,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_433",
+    "statNm": "익명_충전소_433",
+    "addr": "익명_주소",
+    "lat": 37.56215492102526,
+    "lng": 127.02137040764984,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_434",
+    "statNm": "익명_충전소_434",
+    "addr": "익명_주소",
+    "lat": 37.51421417849179,
+    "lng": 127.04226082533609,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_435",
+    "statNm": "익명_충전소_435",
+    "addr": "익명_주소",
+    "lat": 37.50446140402848,
+    "lng": 126.96356350262744,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_436",
+    "statNm": "익명_충전소_436",
+    "addr": "익명_주소",
+    "lat": 37.51519952901415,
+    "lng": 127.01863876127956,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_437",
+    "statNm": "익명_충전소_437",
+    "addr": "익명_주소",
+    "lat": 37.52503218271137,
+    "lng": 126.93504591330714,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_438",
+    "statNm": "익명_충전소_438",
+    "addr": "익명_주소",
+    "lat": 37.63485291697421,
+    "lng": 127.01736945787655,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_439",
+    "statNm": "익명_충전소_439",
+    "addr": "익명_주소",
+    "lat": 37.52374877650323,
+    "lng": 126.95196085747202,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_440",
+    "statNm": "익명_충전소_440",
+    "addr": "익명_주소",
+    "lat": 37.606913330541204,
+    "lng": 126.91538561732699,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_441",
+    "statNm": "익명_충전소_441",
+    "addr": "익명_주소",
+    "lat": 37.54969699194562,
+    "lng": 126.89791492348095,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_442",
+    "statNm": "익명_충전소_442",
+    "addr": "익명_주소",
+    "lat": 37.58453556796072,
+    "lng": 127.04816362748254,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_443",
+    "statNm": "익명_충전소_443",
+    "addr": "익명_주소",
+    "lat": 37.527552020616824,
+    "lng": 126.99875197780453,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_444",
+    "statNm": "익명_충전소_444",
+    "addr": "익명_주소",
+    "lat": 37.502203013284095,
+    "lng": 126.95684434291539,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_445",
+    "statNm": "익명_충전소_445",
+    "addr": "익명_주소",
+    "lat": 37.52264438997277,
+    "lng": 127.04140389511826,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_446",
+    "statNm": "익명_충전소_446",
+    "addr": "익명_주소",
+    "lat": 37.58820741996458,
+    "lng": 126.94173519595626,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_447",
+    "statNm": "익명_충전소_447",
+    "addr": "익명_주소",
+    "lat": 37.51291546606693,
+    "lng": 127.05717588524067,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "없음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_448",
+    "statNm": "익명_충전소_448",
+    "addr": "익명_주소",
+    "lat": 37.512992336342734,
+    "lng": 126.95265631032342,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_449",
+    "statNm": "익명_충전소_449",
+    "addr": "익명_주소",
+    "lat": 37.54367090532454,
+    "lng": 126.94932492740847,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_450",
+    "statNm": "익명_충전소_450",
+    "addr": "익명_주소",
+    "lat": 37.536142579183654,
+    "lng": 126.93895209514169,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_451",
+    "statNm": "익명_충전소_451",
+    "addr": "익명_주소",
+    "lat": 37.48822441212285,
+    "lng": 126.95253222700529,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_452",
+    "statNm": "익명_충전소_452",
+    "addr": "익명_주소",
+    "lat": 37.545467604895265,
+    "lng": 126.91407137904547,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 14
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 14
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_453",
+    "statNm": "익명_충전소_453",
+    "addr": "익명_주소",
+    "lat": 37.572214521652384,
+    "lng": 127.01858558090717,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 14
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 14
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_454",
+    "statNm": "익명_충전소_454",
+    "addr": "익명_주소",
+    "lat": 37.594807839873255,
+    "lng": 126.90014009036229,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_455",
+    "statNm": "익명_충전소_455",
+    "addr": "익명_주소",
+    "lat": 37.6322070466903,
+    "lng": 126.91278893619648,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 출입불가",
+    "note": "외부인 출입불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_456",
+    "statNm": "익명_충전소_456",
+    "addr": "익명_주소",
+    "lat": 37.58569811430043,
+    "lng": 126.89767432171473,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_457",
+    "statNm": "익명_충전소_457",
+    "addr": "익명_주소",
+    "lat": 37.5297456768054,
+    "lng": 127.0212855896176,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_458",
+    "statNm": "익명_충전소_458",
+    "addr": "익명_주소",
+    "lat": 37.587512970833075,
+    "lng": 126.89502114399346,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_459",
+    "statNm": "익명_충전소_459",
+    "addr": "익명_주소",
+    "lat": 37.58056737881878,
+    "lng": 126.88081697627284,
+    "useTime": "24시간 이용가능 (주차 자단기 설치됨 등록 입주민 외 이용불가)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_460",
+    "statNm": "익명_충전소_460",
+    "addr": "익명_주소",
+    "lat": 37.60896035857796,
+    "lng": 126.93817126415694,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_461",
+    "statNm": "익명_충전소_461",
+    "addr": "익명_주소",
+    "lat": 37.62629168568182,
+    "lng": 127.06524934659724,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_462",
+    "statNm": "익명_충전소_462",
+    "addr": "익명_주소",
+    "lat": 37.62707057042734,
+    "lng": 126.98228117233492,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_463",
+    "statNm": "익명_충전소_463",
+    "addr": "익명_주소",
+    "lat": 37.557765432042586,
+    "lng": 126.92464794944132,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_464",
+    "statNm": "익명_충전소_464",
+    "addr": "익명_주소",
+    "lat": 37.52808430587046,
+    "lng": 126.93828547093081,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_465",
+    "statNm": "익명_충전소_465",
+    "addr": "익명_주소",
+    "lat": 37.54751882408099,
+    "lng": 126.96996984241113,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_466",
+    "statNm": "익명_충전소_466",
+    "addr": "익명_주소",
+    "lat": 37.62839632723876,
+    "lng": 127.05178411475887,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_467",
+    "statNm": "익명_충전소_467",
+    "addr": "익명_주소",
+    "lat": 37.59446341436888,
+    "lng": 126.97748797036259,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_468",
+    "statNm": "익명_충전소_468",
+    "addr": "익명_주소",
+    "lat": 37.50584874595281,
+    "lng": 126.91503235622736,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_469",
+    "statNm": "익명_충전소_469",
+    "addr": "익명_주소",
+    "lat": 37.57905766980799,
+    "lng": 126.97710927018049,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_470",
+    "statNm": "익명_충전소_470",
+    "addr": "익명_주소",
+    "lat": 37.534798863732746,
+    "lng": 126.9409729510807,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_471",
+    "statNm": "익명_충전소_471",
+    "addr": "익명_주소",
+    "lat": 37.498338821316175,
+    "lng": 126.92489696581949,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_472",
+    "statNm": "익명_충전소_472",
+    "addr": "익명_주소",
+    "lat": 37.50643134895183,
+    "lng": 126.89967339470365,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_473",
+    "statNm": "익명_충전소_473",
+    "addr": "익명_주소",
+    "lat": 37.523944495192055,
+    "lng": 126.97707192859974,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "외부인 출입불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "1",
+        "output": 320
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_474",
+    "statNm": "익명_충전소_474",
+    "addr": "익명_주소",
+    "lat": 37.52876084743484,
+    "lng": 126.98296854348484,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_475",
+    "statNm": "익명_충전소_475",
+    "addr": "익명_주소",
+    "lat": 37.602788174721695,
+    "lng": 126.90607967945039,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_476",
+    "statNm": "익명_충전소_476",
+    "addr": "익명_주소",
+    "lat": 37.59964432350921,
+    "lng": 127.01364753078613,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_477",
+    "statNm": "익명_충전소_477",
+    "addr": "익명_주소",
+    "lat": 37.58455011326953,
+    "lng": 126.89066101180431,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_478",
+    "statNm": "익명_충전소_478",
+    "addr": "익명_주소",
+    "lat": 37.5923674664666,
+    "lng": 126.9883195454556,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_479",
+    "statNm": "익명_충전소_479",
+    "addr": "익명_주소",
+    "lat": 37.57809165826424,
+    "lng": 126.98725232220734,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_480",
+    "statNm": "익명_충전소_480",
+    "addr": "익명_주소",
+    "lat": 37.5532833730765,
+    "lng": 127.05680801013774,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_481",
+    "statNm": "익명_충전소_481",
+    "addr": "익명_주소",
+    "lat": 37.59108240652947,
+    "lng": 127.00154985213054,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_482",
+    "statNm": "익명_충전소_482",
+    "addr": "익명_주소",
+    "lat": 37.56219026730277,
+    "lng": 127.07149147586912,
+    "useTime": "24시간 이용가능 (외부인 이용불가)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 이용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_483",
+    "statNm": "익명_충전소_483",
+    "addr": "익명_주소",
+    "lat": 37.57011630204636,
+    "lng": 126.98130815841823,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_484",
+    "statNm": "익명_충전소_484",
+    "addr": "익명_주소",
+    "lat": 37.6006304535607,
+    "lng": 127.03796426276891,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_485",
+    "statNm": "익명_충전소_485",
+    "addr": "익명_주소",
+    "lat": 37.558467327702886,
+    "lng": 126.88623734947686,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_486",
+    "statNm": "익명_충전소_486",
+    "addr": "익명_주소",
+    "lat": 37.57055787810659,
+    "lng": 127.0500370590543,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_487",
+    "statNm": "익명_충전소_487",
+    "addr": "익명_주소",
+    "lat": 37.602152492394374,
+    "lng": 126.96837685296165,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_488",
+    "statNm": "익명_충전소_488",
+    "addr": "익명_주소",
+    "lat": 37.59553778520959,
+    "lng": 127.06357138590442,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 출입 및 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_489",
+    "statNm": "익명_충전소_489",
+    "addr": "익명_주소",
+    "lat": 37.50390961456074,
+    "lng": 127.02864890909598,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_490",
+    "statNm": "익명_충전소_490",
+    "addr": "익명_주소",
+    "lat": 37.533436748458456,
+    "lng": 126.98014906722987,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_491",
+    "statNm": "익명_충전소_491",
+    "addr": "익명_주소",
+    "lat": 37.63047431877893,
+    "lng": 127.008073164779,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_492",
+    "statNm": "익명_충전소_492",
+    "addr": "익명_주소",
+    "lat": 37.61181015828299,
+    "lng": 127.01120846440652,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_493",
+    "statNm": "익명_충전소_493",
+    "addr": "익명_주소",
+    "lat": 37.63896851451492,
+    "lng": 126.99922221861355,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입제한",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_494",
+    "statNm": "익명_충전소_494",
+    "addr": "익명_주소",
+    "lat": 37.52381734544261,
+    "lng": 126.95789510588057,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_495",
+    "statNm": "익명_충전소_495",
+    "addr": "익명_주소",
+    "lat": 37.568613968821126,
+    "lng": 126.89874081263774,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_496",
+    "statNm": "익명_충전소_496",
+    "addr": "익명_주소",
+    "lat": 37.590709019443956,
+    "lng": 127.05839618433208,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_497",
+    "statNm": "익명_충전소_497",
+    "addr": "익명_주소",
+    "lat": 37.570191523686475,
+    "lng": 126.9673323702879,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "시설 상황에 따라 제한 될 수 있음",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_498",
+    "statNm": "익명_충전소_498",
+    "addr": "익명_주소",
+    "lat": 37.5175453648193,
+    "lng": 126.96364985684563,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_499",
+    "statNm": "익명_충전소_499",
+    "addr": "익명_주소",
+    "lat": 37.61913987414271,
+    "lng": 126.96402783530706,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1644-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 9,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_500",
+    "statNm": "익명_충전소_500",
+    "addr": "익명_주소",
+    "lat": 37.53013832394415,
+    "lng": 127.02788135104811,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "21",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_501",
+    "statNm": "익명_충전소_501",
+    "addr": "익명_주소",
+    "lat": 37.57031438356099,
+    "lng": 126.95604979033448,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_502",
+    "statNm": "익명_충전소_502",
+    "addr": "익명_주소",
+    "lat": 37.60295323295407,
+    "lng": 127.01687868766369,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_503",
+    "statNm": "익명_충전소_503",
+    "addr": "익명_주소",
+    "lat": 37.63547891818528,
+    "lng": 126.9689144315758,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_504",
+    "statNm": "익명_충전소_504",
+    "addr": "익명_주소",
+    "lat": 37.51144266248899,
+    "lng": 126.97681127641573,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_505",
+    "statNm": "익명_충전소_505",
+    "addr": "익명_주소",
+    "lat": 37.54579523898052,
+    "lng": 127.07993076849506,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "031370XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "51",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "87",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "90",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_506",
+    "statNm": "익명_충전소_506",
+    "addr": "익명_주소",
+    "lat": 37.515998945953584,
+    "lng": 127.04800445063306,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_507",
+    "statNm": "익명_충전소_507",
+    "addr": "익명_주소",
+    "lat": 37.49267415956844,
+    "lng": 127.01125257690684,
+    "useTime": "24시간 이용가능(입주민 외 이용제한 있을 수 있음)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_508",
+    "statNm": "익명_충전소_508",
+    "addr": "익명_주소",
+    "lat": 37.58131051768437,
+    "lng": 126.9690788733884,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 출입불가",
+    "note": "외부인 출입불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_509",
+    "statNm": "익명_충전소_509",
+    "addr": "익명_주소",
+    "lat": 37.63199899643484,
+    "lng": 126.94130522365514,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_510",
+    "statNm": "익명_충전소_510",
+    "addr": "익명_주소",
+    "lat": 37.559973120414156,
+    "lng": 126.99034829839408,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_511",
+    "statNm": "익명_충전소_511",
+    "addr": "익명_주소",
+    "lat": 37.58107865544588,
+    "lng": 126.94292140890435,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_512",
+    "statNm": "익명_충전소_512",
+    "addr": "익명_주소",
+    "lat": 37.56916330796226,
+    "lng": 127.05600283913545,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_513",
+    "statNm": "익명_충전소_513",
+    "addr": "익명_주소",
+    "lat": 37.58755681645875,
+    "lng": 127.03058181662585,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_514",
+    "statNm": "익명_충전소_514",
+    "addr": "익명_주소",
+    "lat": 37.523578019621304,
+    "lng": 127.05205017701414,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_515",
+    "statNm": "익명_충전소_515",
+    "addr": "익명_주소",
+    "lat": 37.633289837742055,
+    "lng": 126.9898184153184,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_516",
+    "statNm": "익명_충전소_516",
+    "addr": "익명_주소",
+    "lat": 37.51421181846003,
+    "lng": 126.92219999031592,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_517",
+    "statNm": "익명_충전소_517",
+    "addr": "익명_주소",
+    "lat": 37.562974175948604,
+    "lng": 127.07076918872416,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_518",
+    "statNm": "익명_충전소_518",
+    "addr": "익명_주소",
+    "lat": 37.604853937432004,
+    "lng": 127.03076717710728,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_519",
+    "statNm": "익명_충전소_519",
+    "addr": "익명_주소",
+    "lat": 37.581781392797986,
+    "lng": 127.03860328609133,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_520",
+    "statNm": "익명_충전소_520",
+    "addr": "익명_주소",
+    "lat": 37.538146540093166,
+    "lng": 127.07647891737605,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_521",
+    "statNm": "익명_충전소_521",
+    "addr": "익명_주소",
+    "lat": 37.532032801659064,
+    "lng": 127.03751078193072,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_522",
+    "statNm": "익명_충전소_522",
+    "addr": "익명_주소",
+    "lat": 37.574388106457455,
+    "lng": 126.96030809574921,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "1",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_523",
+    "statNm": "익명_충전소_523",
+    "addr": "익명_주소",
+    "lat": 37.56985407698857,
+    "lng": 127.01502383171713,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_524",
+    "statNm": "익명_충전소_524",
+    "addr": "익명_주소",
+    "lat": 37.57341394709633,
+    "lng": 127.03071926471563,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_525",
+    "statNm": "익명_충전소_525",
+    "addr": "익명_주소",
+    "lat": 37.57915485782354,
+    "lng": 127.01675007249628,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 전용",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_526",
+    "statNm": "익명_충전소_526",
+    "addr": "익명_주소",
+    "lat": 37.48901401209621,
+    "lng": 126.94176962362961,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_527",
+    "statNm": "익명_충전소_527",
+    "addr": "익명_주소",
+    "lat": 37.540431459287035,
+    "lng": 126.95610275481621,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_528",
+    "statNm": "익명_충전소_528",
+    "addr": "익명_주소",
+    "lat": 37.53803808787991,
+    "lng": 126.97398949452376,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_529",
+    "statNm": "익명_충전소_529",
+    "addr": "익명_주소",
+    "lat": 37.55684322777218,
+    "lng": 126.94812646448528,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_530",
+    "statNm": "익명_충전소_530",
+    "addr": "익명_주소",
+    "lat": 37.610558876581266,
+    "lng": 126.97338131261309,
+    "useTime": "24시간 이용가능(입주민 외 이용제한 있을 수 있음)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_531",
+    "statNm": "익명_충전소_531",
+    "addr": "익명_주소",
+    "lat": 37.583740913140616,
+    "lng": 126.94700182161141,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_532",
+    "statNm": "익명_충전소_532",
+    "addr": "익명_주소",
+    "lat": 37.62772597357507,
+    "lng": 127.00134242976088,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따란 이용이 제한될 수 있음",
+    "note": "시설 상황에 따라 제한 될 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 40
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_533",
+    "statNm": "익명_충전소_533",
+    "addr": "익명_주소",
+    "lat": 37.52895847686338,
+    "lng": 126.95851570433427,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "031-922-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "해당사항 없음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_534",
+    "statNm": "익명_충전소_534",
+    "addr": "익명_주소",
+    "lat": 37.578157235650934,
+    "lng": 126.88541913210574,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_535",
+    "statNm": "익명_충전소_535",
+    "addr": "익명_주소",
+    "lat": 37.53435196207689,
+    "lng": 126.98585811350065,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_536",
+    "statNm": "익명_충전소_536",
+    "addr": "익명_주소",
+    "lat": 37.554364494161455,
+    "lng": 126.917459666608,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_537",
+    "statNm": "익명_충전소_537",
+    "addr": "익명_주소",
+    "lat": 37.51060749446148,
+    "lng": 126.88739517062668,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_538",
+    "statNm": "익명_충전소_538",
+    "addr": "익명_주소",
+    "lat": 37.5960972563314,
+    "lng": 127.0663276690264,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_539",
+    "statNm": "익명_충전소_539",
+    "addr": "익명_주소",
+    "lat": 37.52787234076462,
+    "lng": 127.06696525320076,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_540",
+    "statNm": "익명_충전소_540",
+    "addr": "익명_주소",
+    "lat": 37.60193745146637,
+    "lng": 127.00172557656384,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민만 사용가능, 거주자외 출입제한",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_541",
+    "statNm": "익명_충전소_541",
+    "addr": "익명_주소",
+    "lat": 37.56188207925252,
+    "lng": 126.93670908067278,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_542",
+    "statNm": "익명_충전소_542",
+    "addr": "익명_주소",
+    "lat": 37.511147240288125,
+    "lng": 127.04075965877028,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_543",
+    "statNm": "익명_충전소_543",
+    "addr": "익명_주소",
+    "lat": 37.595827508038965,
+    "lng": 126.99680807454016,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 9,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_544",
+    "statNm": "익명_충전소_544",
+    "addr": "익명_주소",
+    "lat": 37.62281477651256,
+    "lng": 126.93219596633513,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_545",
+    "statNm": "익명_충전소_545",
+    "addr": "익명_주소",
+    "lat": 37.61958102682866,
+    "lng": 127.02767210912964,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_546",
+    "statNm": "익명_충전소_546",
+    "addr": "익명_주소",
+    "lat": 37.5199417559602,
+    "lng": 126.94104422222624,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_547",
+    "statNm": "익명_충전소_547",
+    "addr": "익명_주소",
+    "lat": 37.57840363932904,
+    "lng": 126.96854430674367,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입제한",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_548",
+    "statNm": "익명_충전소_548",
+    "addr": "익명_주소",
+    "lat": 37.55151351376634,
+    "lng": 126.98574698317132,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "이XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_549",
+    "statNm": "익명_충전소_549",
+    "addr": "익명_주소",
+    "lat": 37.555812365904025,
+    "lng": 127.09051454584319,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_550",
+    "statNm": "익명_충전소_550",
+    "addr": "익명_주소",
+    "lat": 37.5719118743557,
+    "lng": 127.05480252922378,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_551",
+    "statNm": "익명_충전소_551",
+    "addr": "익명_주소",
+    "lat": 37.53696999180157,
+    "lng": 126.96091680733235,
+    "useTime": "24시간 이용가능(입주민 외 이용제한 있을 수 있음)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_552",
+    "statNm": "익명_충전소_552",
+    "addr": "익명_주소",
+    "lat": 37.54713032077546,
+    "lng": 126.88938692590884,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_553",
+    "statNm": "익명_충전소_553",
+    "addr": "익명_주소",
+    "lat": 37.599676448072756,
+    "lng": 126.87162623470671,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_554",
+    "statNm": "익명_충전소_554",
+    "addr": "익명_주소",
+    "lat": 37.56075485375047,
+    "lng": 127.01122056387861,
+    "useTime": "평일 10:00-17:00/토,휴일 10:00-20:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_555",
+    "statNm": "익명_충전소_555",
+    "addr": "익명_주소",
+    "lat": 37.575030235201936,
+    "lng": 127.0577809667787,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_556",
+    "statNm": "익명_충전소_556",
+    "addr": "익명_주소",
+    "lat": 37.57815124852528,
+    "lng": 126.89008475283238,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_557",
+    "statNm": "익명_충전소_557",
+    "addr": "익명_주소",
+    "lat": 37.593600724113045,
+    "lng": 126.9120489262804,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_558",
+    "statNm": "익명_충전소_558",
+    "addr": "익명_주소",
+    "lat": 37.587964482807486,
+    "lng": 127.07600702738574,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_559",
+    "statNm": "익명_충전소_559",
+    "addr": "익명_주소",
+    "lat": 37.550828233110266,
+    "lng": 126.89485561764107,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_560",
+    "statNm": "익명_충전소_560",
+    "addr": "익명_주소",
+    "lat": 37.59735587056704,
+    "lng": 127.08532682031947,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_561",
+    "statNm": "익명_충전소_561",
+    "addr": "익명_주소",
+    "lat": 37.52928993026276,
+    "lng": 126.92557285832802,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "1",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "1",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_562",
+    "statNm": "익명_충전소_562",
+    "addr": "익명_주소",
+    "lat": 37.580953197014615,
+    "lng": 127.0750115597277,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_563",
+    "statNm": "익명_충전소_563",
+    "addr": "익명_주소",
+    "lat": 37.50150543195336,
+    "lng": 126.98761184810938,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_564",
+    "statNm": "익명_충전소_564",
+    "addr": "익명_주소",
+    "lat": 37.5057743677606,
+    "lng": 126.87167470135074,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_565",
+    "statNm": "익명_충전소_565",
+    "addr": "익명_주소",
+    "lat": 37.58417325021262,
+    "lng": 127.03719715227739,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "11",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_566",
+    "statNm": "익명_충전소_566",
+    "addr": "익명_주소",
+    "lat": 37.52974777378198,
+    "lng": 126.91374358013053,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_567",
+    "statNm": "익명_충전소_567",
+    "addr": "익명_주소",
+    "lat": 37.59791588669389,
+    "lng": 126.99754396090802,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_568",
+    "statNm": "익명_충전소_568",
+    "addr": "익명_주소",
+    "lat": 37.58115348326642,
+    "lng": 127.05571577312593,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_569",
+    "statNm": "익명_충전소_569",
+    "addr": "익명_주소",
+    "lat": 37.61016890277476,
+    "lng": 126.9888651130309,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_570",
+    "statNm": "익명_충전소_570",
+    "addr": "익명_주소",
+    "lat": 37.58407227419099,
+    "lng": 126.97323625297325,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 12,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_571",
+    "statNm": "익명_충전소_571",
+    "addr": "익명_주소",
+    "lat": 37.58823381328183,
+    "lng": 127.03165105214855,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_572",
+    "statNm": "익명_충전소_572",
+    "addr": "익명_주소",
+    "lat": 37.586758338722845,
+    "lng": 126.90787712994467,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_573",
+    "statNm": "익명_충전소_573",
+    "addr": "익명_주소",
+    "lat": 37.529857853346236,
+    "lng": 126.971901753426,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_574",
+    "statNm": "익명_충전소_574",
+    "addr": "익명_주소",
+    "lat": 37.608907626733114,
+    "lng": 126.96185537048252,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_575",
+    "statNm": "익명_충전소_575",
+    "addr": "익명_주소",
+    "lat": 37.549061356206664,
+    "lng": 126.94055633346518,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_576",
+    "statNm": "익명_충전소_576",
+    "addr": "익명_주소",
+    "lat": 37.58157820941669,
+    "lng": 126.91242191514247,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_577",
+    "statNm": "익명_충전소_577",
+    "addr": "익명_주소",
+    "lat": 37.557167677735364,
+    "lng": 126.95204359703438,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_578",
+    "statNm": "익명_충전소_578",
+    "addr": "익명_주소",
+    "lat": 37.637030447637585,
+    "lng": 127.04181849498495,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_579",
+    "statNm": "익명_충전소_579",
+    "addr": "익명_주소",
+    "lat": 37.559210179106564,
+    "lng": 126.94667577284976,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_580",
+    "statNm": "익명_충전소_580",
+    "addr": "익명_주소",
+    "lat": 37.55912248121829,
+    "lng": 127.07505898833952,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_581",
+    "statNm": "익명_충전소_581",
+    "addr": "익명_주소",
+    "lat": 37.551120516699264,
+    "lng": 126.8881858801214,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_582",
+    "statNm": "익명_충전소_582",
+    "addr": "익명_주소",
+    "lat": 37.567414023806926,
+    "lng": 127.00847780879975,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "11",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 200
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_583",
+    "statNm": "익명_충전소_583",
+    "addr": "익명_주소",
+    "lat": 37.5591360348433,
+    "lng": 126.94964642202942,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_584",
+    "statNm": "익명_충전소_584",
+    "addr": "익명_주소",
+    "lat": 37.59201792061153,
+    "lng": 126.94822003451615,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_585",
+    "statNm": "익명_충전소_585",
+    "addr": "익명_주소",
+    "lat": 37.55425604633568,
+    "lng": 126.96489787848782,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_586",
+    "statNm": "익명_충전소_586",
+    "addr": "익명_주소",
+    "lat": 37.54302010034951,
+    "lng": 126.89572359160596,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_587",
+    "statNm": "익명_충전소_587",
+    "addr": "익명_주소",
+    "lat": 37.574690601437084,
+    "lng": 127.00320988886607,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_588",
+    "statNm": "익명_충전소_588",
+    "addr": "익명_주소",
+    "lat": 37.63443119173237,
+    "lng": 127.0618153998474,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_589",
+    "statNm": "익명_충전소_589",
+    "addr": "익명_주소",
+    "lat": 37.64405169422922,
+    "lng": 127.01641294612074,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_590",
+    "statNm": "익명_충전소_590",
+    "addr": "익명_주소",
+    "lat": 37.6084955942447,
+    "lng": 127.05697049879467,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_591",
+    "statNm": "익명_충전소_591",
+    "addr": "익명_주소",
+    "lat": 37.632034338467214,
+    "lng": 127.02811346324296,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_592",
+    "statNm": "익명_충전소_592",
+    "addr": "익명_주소",
+    "lat": 37.56675644108271,
+    "lng": 126.95848324340612,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_593",
+    "statNm": "익명_충전소_593",
+    "addr": "익명_주소",
+    "lat": 37.608093633457564,
+    "lng": 126.90587417915333,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_594",
+    "statNm": "익명_충전소_594",
+    "addr": "익명_주소",
+    "lat": 37.57603452943828,
+    "lng": 126.93039484249486,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_595",
+    "statNm": "익명_충전소_595",
+    "addr": "익명_주소",
+    "lat": 37.61994178681403,
+    "lng": 126.91050294047506,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_596",
+    "statNm": "익명_충전소_596",
+    "addr": "익명_주소",
+    "lat": 37.60132610882272,
+    "lng": 126.97566204419887,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_597",
+    "statNm": "익명_충전소_597",
+    "addr": "익명_주소",
+    "lat": 37.60602267738525,
+    "lng": 126.88027595256864,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_598",
+    "statNm": "익명_충전소_598",
+    "addr": "익명_주소",
+    "lat": 37.583424805644775,
+    "lng": 126.97064054872996,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_599",
+    "statNm": "익명_충전소_599",
+    "addr": "익명_주소",
+    "lat": 37.561107692801414,
+    "lng": 126.95920601470189,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_600",
+    "statNm": "익명_충전소_600",
+    "addr": "익명_주소",
+    "lat": 37.603001332764244,
+    "lng": 126.86832599413562,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_601",
+    "statNm": "익명_충전소_601",
+    "addr": "익명_주소",
+    "lat": 37.59802258355803,
+    "lng": 126.90939769961697,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_602",
+    "statNm": "익명_충전소_602",
+    "addr": "익명_주소",
+    "lat": 37.560974995653325,
+    "lng": 127.09631354856049,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_603",
+    "statNm": "익명_충전소_603",
+    "addr": "익명_주소",
+    "lat": 37.510557488113925,
+    "lng": 126.95951869677941,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_604",
+    "statNm": "익명_충전소_604",
+    "addr": "익명_주소",
+    "lat": 37.55256102563873,
+    "lng": 126.96815410233604,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_605",
+    "statNm": "익명_충전소_605",
+    "addr": "익명_주소",
+    "lat": 37.5937732298267,
+    "lng": 126.91220903651705,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_606",
+    "statNm": "익명_충전소_606",
+    "addr": "익명_주소",
+    "lat": 37.610178055630975,
+    "lng": 126.86892808313497,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_607",
+    "statNm": "익명_충전소_607",
+    "addr": "익명_주소",
+    "lat": 37.556588614068886,
+    "lng": 126.96393186673923,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_608",
+    "statNm": "익명_충전소_608",
+    "addr": "익명_주소",
+    "lat": 37.61715116113226,
+    "lng": 126.98179779258145,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_609",
+    "statNm": "익명_충전소_609",
+    "addr": "익명_주소",
+    "lat": 37.60298578394644,
+    "lng": 126.89574150712834,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_610",
+    "statNm": "익명_충전소_610",
+    "addr": "익명_주소",
+    "lat": 37.60081866379482,
+    "lng": 126.86932209369357,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_611",
+    "statNm": "익명_충전소_611",
+    "addr": "익명_주소",
+    "lat": 37.55299297218825,
+    "lng": 126.88205761926866,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_612",
+    "statNm": "익명_충전소_612",
+    "addr": "익명_주소",
+    "lat": 37.60091712609641,
+    "lng": 126.88504931540389,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_613",
+    "statNm": "익명_충전소_613",
+    "addr": "익명_주소",
+    "lat": 37.562051192995874,
+    "lng": 126.88469732500029,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_614",
+    "statNm": "익명_충전소_614",
+    "addr": "익명_주소",
+    "lat": 37.60632111734747,
+    "lng": 126.94749707470254,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_615",
+    "statNm": "익명_충전소_615",
+    "addr": "익명_주소",
+    "lat": 37.602033631967565,
+    "lng": 126.86377707104673,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_616",
+    "statNm": "익명_충전소_616",
+    "addr": "익명_주소",
+    "lat": 37.562205158719834,
+    "lng": 126.89988973466086,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_617",
+    "statNm": "익명_충전소_617",
+    "addr": "익명_주소",
+    "lat": 37.499076170752275,
+    "lng": 126.94250959710081,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_618",
+    "statNm": "익명_충전소_618",
+    "addr": "익명_주소",
+    "lat": 37.539217877831234,
+    "lng": 126.88189726329634,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_619",
+    "statNm": "익명_충전소_619",
+    "addr": "익명_주소",
+    "lat": 37.561242315087476,
+    "lng": 126.93678482213782,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_620",
+    "statNm": "익명_충전소_620",
+    "addr": "익명_주소",
+    "lat": 37.56072362565355,
+    "lng": 127.07746638104587,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입제한",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_621",
+    "statNm": "익명_충전소_621",
+    "addr": "익명_주소",
+    "lat": 37.6204076331251,
+    "lng": 126.88893221688807,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_622",
+    "statNm": "익명_충전소_622",
+    "addr": "익명_주소",
+    "lat": 37.633709618667744,
+    "lng": 126.96436758344592,
+    "useTime": "09:00~18:00(토/일/공휴일 제외)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_623",
+    "statNm": "익명_충전소_623",
+    "addr": "익명_주소",
+    "lat": 37.6440841014373,
+    "lng": 126.90111632002098,
+    "useTime": "09:00~18:00(토/일/공휴일 제외)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_624",
+    "statNm": "익명_충전소_624",
+    "addr": "익명_주소",
+    "lat": 37.54089851837612,
+    "lng": 126.86749345736203,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_625",
+    "statNm": "익명_충전소_625",
+    "addr": "익명_주소",
+    "lat": 37.59374407768708,
+    "lng": 126.90189062613469,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_626",
+    "statNm": "익명_충전소_626",
+    "addr": "익명_주소",
+    "lat": 37.5246983697188,
+    "lng": 126.90591744392584,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_627",
+    "statNm": "익명_충전소_627",
+    "addr": "익명_주소",
+    "lat": 37.56022372589355,
+    "lng": 126.96430167889042,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_628",
+    "statNm": "익명_충전소_628",
+    "addr": "익명_주소",
+    "lat": 37.57692864430156,
+    "lng": 127.07722069236684,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_629",
+    "statNm": "익명_충전소_629",
+    "addr": "익명_주소",
+    "lat": 37.55045550433759,
+    "lng": 126.91676684534379,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_630",
+    "statNm": "익명_충전소_630",
+    "addr": "익명_주소",
+    "lat": 37.610690364079865,
+    "lng": 126.99730355404648,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "시설 상황에 따라 사용 제한 될 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_631",
+    "statNm": "익명_충전소_631",
+    "addr": "익명_주소",
+    "lat": 37.55751444781961,
+    "lng": 126.8746212718214,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_632",
+    "statNm": "익명_충전소_632",
+    "addr": "익명_주소",
+    "lat": 37.52523108372666,
+    "lng": 126.89892977857316,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_633",
+    "statNm": "익명_충전소_633",
+    "addr": "익명_주소",
+    "lat": 37.61137004128771,
+    "lng": 126.88451841731832,
+    "useTime": "24시간 이용가능(입주민 외 이용제한 있을 수 있음)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_634",
+    "statNm": "익명_충전소_634",
+    "addr": "익명_주소",
+    "lat": 37.57068885845627,
+    "lng": 126.87795983929055,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_635",
+    "statNm": "익명_충전소_635",
+    "addr": "익명_주소",
+    "lat": 37.60925169057233,
+    "lng": 126.93688339147144,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_636",
+    "statNm": "익명_충전소_636",
+    "addr": "익명_주소",
+    "lat": 37.60915171166386,
+    "lng": 127.01541550456916,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_637",
+    "statNm": "익명_충전소_637",
+    "addr": "익명_주소",
+    "lat": 37.52705262895433,
+    "lng": 126.91505575904367,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_638",
+    "statNm": "익명_충전소_638",
+    "addr": "익명_주소",
+    "lat": 37.607497828391594,
+    "lng": 126.86487029430934,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_639",
+    "statNm": "익명_충전소_639",
+    "addr": "익명_주소",
+    "lat": 37.555117986335915,
+    "lng": 126.88499448022112,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_640",
+    "statNm": "익명_충전소_640",
+    "addr": "익명_주소",
+    "lat": 37.58302718680207,
+    "lng": 127.05112987733169,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "4",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "4",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "4",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_641",
+    "statNm": "익명_충전소_641",
+    "addr": "익명_주소",
+    "lat": 37.56286931858755,
+    "lng": 126.97117978221493,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_642",
+    "statNm": "익명_충전소_642",
+    "addr": "익명_주소",
+    "lat": 37.56446962188632,
+    "lng": 126.91445258810168,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_643",
+    "statNm": "익명_충전소_643",
+    "addr": "익명_주소",
+    "lat": 37.48976275532239,
+    "lng": 127.05612595051248,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_644",
+    "statNm": "익명_충전소_644",
+    "addr": "익명_주소",
+    "lat": 37.60874315035528,
+    "lng": 127.02682439938555,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 15,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "14",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "15",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_645",
+    "statNm": "익명_충전소_645",
+    "addr": "익명_주소",
+    "lat": 37.58617301681203,
+    "lng": 127.00256105194669,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_646",
+    "statNm": "익명_충전소_646",
+    "addr": "익명_주소",
+    "lat": 37.58024801264488,
+    "lng": 127.02433828920744,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_647",
+    "statNm": "익명_충전소_647",
+    "addr": "익명_주소",
+    "lat": 37.600745054453625,
+    "lng": 127.00588603004222,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_648",
+    "statNm": "익명_충전소_648",
+    "addr": "익명_주소",
+    "lat": 37.601293886675116,
+    "lng": 126.97420029225042,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "시설 상황에 따라 제한 될 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_649",
+    "statNm": "익명_충전소_649",
+    "addr": "익명_주소",
+    "lat": 37.64634098051465,
+    "lng": 127.01311840246737,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "시설 상황에 따라 제한 될 수 있음",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_650",
+    "statNm": "익명_충전소_650",
+    "addr": "익명_주소",
+    "lat": 37.60983855819444,
+    "lng": 126.95307328876493,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_651",
+    "statNm": "익명_충전소_651",
+    "addr": "익명_주소",
+    "lat": 37.60064306012997,
+    "lng": 126.89936276340951,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_652",
+    "statNm": "익명_충전소_652",
+    "addr": "익명_주소",
+    "lat": 37.59700109793994,
+    "lng": 127.05387522993344,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_653",
+    "statNm": "익명_충전소_653",
+    "addr": "익명_주소",
+    "lat": 37.59425497084379,
+    "lng": 127.05997199647523,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_654",
+    "statNm": "익명_충전소_654",
+    "addr": "익명_주소",
+    "lat": 37.61305780152517,
+    "lng": 127.06527240856853,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_655",
+    "statNm": "익명_충전소_655",
+    "addr": "익명_주소",
+    "lat": 37.63567292040877,
+    "lng": 127.04330414749859,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_656",
+    "statNm": "익명_충전소_656",
+    "addr": "익명_주소",
+    "lat": 37.61652889922517,
+    "lng": 126.98927130629848,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 9,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_657",
+    "statNm": "익명_충전소_657",
+    "addr": "익명_주소",
+    "lat": 37.54373608693248,
+    "lng": 126.94183180639472,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 전용",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_658",
+    "statNm": "익명_충전소_658",
+    "addr": "익명_주소",
+    "lat": 37.61403097662362,
+    "lng": 126.89766203548307,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 전용",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_659",
+    "statNm": "익명_충전소_659",
+    "addr": "익명_주소",
+    "lat": 37.59850934140952,
+    "lng": 126.92964807189348,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_660",
+    "statNm": "익명_충전소_660",
+    "addr": "익명_주소",
+    "lat": 37.61419134940746,
+    "lng": 126.8646259114597,
+    "useTime": "24시간 이용가능(입주민 외 이용제한 있을 수 있음)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_661",
+    "statNm": "익명_충전소_661",
+    "addr": "익명_주소",
+    "lat": 37.572144188850444,
+    "lng": 127.06368979424123,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_662",
+    "statNm": "익명_충전소_662",
+    "addr": "익명_주소",
+    "lat": 37.587203539673816,
+    "lng": 127.00160098516004,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용금지",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_663",
+    "statNm": "익명_충전소_663",
+    "addr": "익명_주소",
+    "lat": 37.58398038613066,
+    "lng": 127.06209556188179,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "시설 상황에 따라 사용 제한 될 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 40
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_664",
+    "statNm": "익명_충전소_664",
+    "addr": "익명_주소",
+    "lat": 37.551310312769054,
+    "lng": 126.94348373160291,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_665",
+    "statNm": "익명_충전소_665",
+    "addr": "익명_주소",
+    "lat": 37.62827071821529,
+    "lng": 126.95351272644096,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "06",
+        "stat": "3",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_666",
+    "statNm": "익명_충전소_666",
+    "addr": "익명_주소",
+    "lat": 37.55310169127343,
+    "lng": 126.95210707631043,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "화장실 : 건물내 화장실 24시간 이용가능",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_667",
+    "statNm": "익명_충전소_667",
+    "addr": "익명_주소",
+    "lat": 37.60453567870584,
+    "lng": 127.01602678299444,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용금지",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_668",
+    "statNm": "익명_충전소_668",
+    "addr": "익명_주소",
+    "lat": 37.595282975379824,
+    "lng": 127.0592195563465,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_669",
+    "statNm": "익명_충전소_669",
+    "addr": "익명_주소",
+    "lat": 37.64076257513647,
+    "lng": 127.0159725281543,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_670",
+    "statNm": "익명_충전소_670",
+    "addr": "익명_주소",
+    "lat": 37.58347897597424,
+    "lng": 126.93153434656082,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_671",
+    "statNm": "익명_충전소_671",
+    "addr": "익명_주소",
+    "lat": 37.57844225168538,
+    "lng": 127.04159875062743,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_672",
+    "statNm": "익명_충전소_672",
+    "addr": "익명_주소",
+    "lat": 37.65909873747637,
+    "lng": 127.00086769237944,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_673",
+    "statNm": "익명_충전소_673",
+    "addr": "익명_주소",
+    "lat": 37.59772583265757,
+    "lng": 126.95986419049888,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_674",
+    "statNm": "익명_충전소_674",
+    "addr": "익명_주소",
+    "lat": 37.64550318180264,
+    "lng": 127.00840438325932,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_675",
+    "statNm": "익명_충전소_675",
+    "addr": "익명_주소",
+    "lat": 37.64883200269523,
+    "lng": 126.98790326217414,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_676",
+    "statNm": "익명_충전소_676",
+    "addr": "익명_주소",
+    "lat": 37.592311414175526,
+    "lng": 126.8657630143242,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_677",
+    "statNm": "익명_충전소_677",
+    "addr": "익명_주소",
+    "lat": 37.54300944072841,
+    "lng": 126.9996284869575,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_678",
+    "statNm": "익명_충전소_678",
+    "addr": "익명_주소",
+    "lat": 37.63672924108307,
+    "lng": 126.94925943898001,
+    "useTime": "주차장공사로 이용불가(~25.12월말까지)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "9",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_679",
+    "statNm": "익명_충전소_679",
+    "addr": "익명_주소",
+    "lat": 37.54680085014527,
+    "lng": 126.87416078569575,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_680",
+    "statNm": "익명_충전소_680",
+    "addr": "익명_주소",
+    "lat": 37.55880484741196,
+    "lng": 126.94507388386165,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 전용",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_681",
+    "statNm": "익명_충전소_681",
+    "addr": "익명_주소",
+    "lat": 37.60118540408417,
+    "lng": 127.0277085484457,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_682",
+    "statNm": "익명_충전소_682",
+    "addr": "익명_주소",
+    "lat": 37.59843725831214,
+    "lng": 127.00343526190417,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용금지",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_683",
+    "statNm": "익명_충전소_683",
+    "addr": "익명_주소",
+    "lat": 37.6200399395727,
+    "lng": 127.01319354863718,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_684",
+    "statNm": "익명_충전소_684",
+    "addr": "익명_주소",
+    "lat": 37.57507441338845,
+    "lng": 127.05925360235872,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_685",
+    "statNm": "익명_충전소_685",
+    "addr": "익명_주소",
+    "lat": 37.552006410592234,
+    "lng": 127.0936747822855,
+    "useTime": "외부인 사용불가",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 출입/사용불가 이용제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_686",
+    "statNm": "익명_충전소_686",
+    "addr": "익명_주소",
+    "lat": 37.62424315589556,
+    "lng": 126.9727843935721,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 12,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_687",
+    "statNm": "익명_충전소_687",
+    "addr": "익명_주소",
+    "lat": 37.58921653887136,
+    "lng": 126.96325322310418,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 전용",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_688",
+    "statNm": "익명_충전소_688",
+    "addr": "익명_주소",
+    "lat": 37.53152704255678,
+    "lng": 127.03900625779382,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1660-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 전용",
+    "note": "입주민 전용",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_689",
+    "statNm": "익명_충전소_689",
+    "addr": "익명_주소",
+    "lat": 37.48131609475279,
+    "lng": 127.01124183738459,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "070-4855-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_690",
+    "statNm": "익명_충전소_690",
+    "addr": "익명_주소",
+    "lat": 37.6194823836585,
+    "lng": 126.88511281122514,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 전용",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_691",
+    "statNm": "익명_충전소_691",
+    "addr": "익명_주소",
+    "lat": 37.561141922846176,
+    "lng": 126.87100527794979,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입제한",
+    "note": "",
+    "totalChargers": 30,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "14",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "15",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "16",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "17",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "18",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "19",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "20",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "21",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "23",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "24",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "25",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "26",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "27",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "28",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "29",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "30",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_692",
+    "statNm": "익명_충전소_692",
+    "addr": "익명_주소",
+    "lat": 37.60109585101772,
+    "lng": 126.95413805316441,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입제한",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_693",
+    "statNm": "익명_충전소_693",
+    "addr": "익명_주소",
+    "lat": 37.558624545459104,
+    "lng": 126.99768979771589,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_694",
+    "statNm": "익명_충전소_694",
+    "addr": "익명_주소",
+    "lat": 37.58860838526497,
+    "lng": 127.01889401271687,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_695",
+    "statNm": "익명_충전소_695",
+    "addr": "익명_주소",
+    "lat": 37.628843041888096,
+    "lng": 127.08384760779829,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_696",
+    "statNm": "익명_충전소_696",
+    "addr": "익명_주소",
+    "lat": 37.63991074423959,
+    "lng": 127.0562493884568,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_697",
+    "statNm": "익명_충전소_697",
+    "addr": "익명_주소",
+    "lat": 37.57549842359029,
+    "lng": 127.05786907628618,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_698",
+    "statNm": "익명_충전소_698",
+    "addr": "익명_주소",
+    "lat": 37.602759954991285,
+    "lng": 127.03352247235708,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_699",
+    "statNm": "익명_충전소_699",
+    "addr": "익명_주소",
+    "lat": 37.63782558057912,
+    "lng": 127.06715056658493,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_700",
+    "statNm": "익명_충전소_700",
+    "addr": "익명_주소",
+    "lat": 37.56046302392585,
+    "lng": 126.94335840290057,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따라 주차비가 발생할 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_701",
+    "statNm": "익명_충전소_701",
+    "addr": "익명_주소",
+    "lat": 37.54715087503459,
+    "lng": 126.86222644143109,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따라 주차비가 발생할 수 있음",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_702",
+    "statNm": "익명_충전소_702",
+    "addr": "익명_주소",
+    "lat": 37.64252018353108,
+    "lng": 127.02035887455578,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_703",
+    "statNm": "익명_충전소_703",
+    "addr": "익명_주소",
+    "lat": 37.583698216568656,
+    "lng": 127.05128799303111,
+    "useTime": "평일 09:00~16:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_704",
+    "statNm": "익명_충전소_704",
+    "addr": "익명_주소",
+    "lat": 37.62049622335184,
+    "lng": 126.98912336602503,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_705",
+    "statNm": "익명_충전소_705",
+    "addr": "익명_주소",
+    "lat": 37.58072364920518,
+    "lng": 126.94686802943339,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "070-4855-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_706",
+    "statNm": "익명_충전소_706",
+    "addr": "익명_주소",
+    "lat": 37.61409012283634,
+    "lng": 127.07835085984046,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_707",
+    "statNm": "익명_충전소_707",
+    "addr": "익명_주소",
+    "lat": 37.60404770748916,
+    "lng": 127.025132593323,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_708",
+    "statNm": "익명_충전소_708",
+    "addr": "익명_주소",
+    "lat": 37.53073897477276,
+    "lng": 126.92498027484964,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_709",
+    "statNm": "익명_충전소_709",
+    "addr": "익명_주소",
+    "lat": 37.63441319244316,
+    "lng": 126.96131041519116,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_710",
+    "statNm": "익명_충전소_710",
+    "addr": "익명_주소",
+    "lat": 37.56053148994601,
+    "lng": 127.0141554109623,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_711",
+    "statNm": "익명_충전소_711",
+    "addr": "익명_주소",
+    "lat": 37.589134597613324,
+    "lng": 126.93055220600282,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_712",
+    "statNm": "익명_충전소_712",
+    "addr": "익명_주소",
+    "lat": 37.649309548265336,
+    "lng": 126.9031103470793,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_713",
+    "statNm": "익명_충전소_713",
+    "addr": "익명_주소",
+    "lat": 37.51477039950248,
+    "lng": 127.02659273025996,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_714",
+    "statNm": "익명_충전소_714",
+    "addr": "익명_주소",
+    "lat": 37.59055302405326,
+    "lng": 127.04193675716974,
+    "useTime": "00:00~23:55",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_715",
+    "statNm": "익명_충전소_715",
+    "addr": "익명_주소",
+    "lat": 37.61850869688708,
+    "lng": 127.0423638732912,
+    "useTime": "00:00~23:55",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_716",
+    "statNm": "익명_충전소_716",
+    "addr": "익명_주소",
+    "lat": 37.53173179337532,
+    "lng": 127.02854703181725,
+    "useTime": "09:00~21:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_717",
+    "statNm": "익명_충전소_717",
+    "addr": "익명_주소",
+    "lat": 37.639735952424864,
+    "lng": 126.96456555429516,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_718",
+    "statNm": "익명_충전소_718",
+    "addr": "익명_주소",
+    "lat": 37.488922697321065,
+    "lng": 126.94143035224788,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "02-2125-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "관계자만 이용 가능",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "48",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_719",
+    "statNm": "익명_충전소_719",
+    "addr": "익명_주소",
+    "lat": 37.50188467762609,
+    "lng": 126.94847684615846,
+    "useTime": "24시간 이용가능(입주민 외 이용제한 있을 수 있음)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_720",
+    "statNm": "익명_충전소_720",
+    "addr": "익명_주소",
+    "lat": 37.60433123470911,
+    "lng": 127.02561463136405,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_721",
+    "statNm": "익명_충전소_721",
+    "addr": "익명_주소",
+    "lat": 37.56584982227482,
+    "lng": 126.95066542750892,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_722",
+    "statNm": "익명_충전소_722",
+    "addr": "익명_주소",
+    "lat": 37.580285247882195,
+    "lng": 127.1005308132439,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_723",
+    "statNm": "익명_충전소_723",
+    "addr": "익명_주소",
+    "lat": 37.62637695096497,
+    "lng": 126.93456485568584,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 출입불가",
+    "note": "외부인 출입불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_724",
+    "statNm": "익명_충전소_724",
+    "addr": "익명_주소",
+    "lat": 37.58488229367398,
+    "lng": 126.94145237989315,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_725",
+    "statNm": "익명_충전소_725",
+    "addr": "익명_주소",
+    "lat": 37.59978141284425,
+    "lng": 127.02275210117917,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_726",
+    "statNm": "익명_충전소_726",
+    "addr": "익명_주소",
+    "lat": 37.61175509094611,
+    "lng": 126.99076491968701,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_727",
+    "statNm": "익명_충전소_727",
+    "addr": "익명_주소",
+    "lat": 37.48386313890017,
+    "lng": 126.96254306850366,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_728",
+    "statNm": "익명_충전소_728",
+    "addr": "익명_주소",
+    "lat": 37.520478511888996,
+    "lng": 126.90250359523355,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_729",
+    "statNm": "익명_충전소_729",
+    "addr": "익명_주소",
+    "lat": 37.603103880693254,
+    "lng": 127.08755003595692,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 출입불가",
+    "note": "외부인 출입불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_730",
+    "statNm": "익명_충전소_730",
+    "addr": "익명_주소",
+    "lat": 37.513726197712515,
+    "lng": 126.9814921017931,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_731",
+    "statNm": "익명_충전소_731",
+    "addr": "익명_주소",
+    "lat": 37.62044293201444,
+    "lng": 127.06840414625144,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_732",
+    "statNm": "익명_충전소_732",
+    "addr": "익명_주소",
+    "lat": 37.49262501939007,
+    "lng": 126.98414569891752,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_733",
+    "statNm": "익명_충전소_733",
+    "addr": "익명_주소",
+    "lat": 37.561046028315275,
+    "lng": 127.02398280625104,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_734",
+    "statNm": "익명_충전소_734",
+    "addr": "익명_주소",
+    "lat": 37.64386386258036,
+    "lng": 127.07059347238284,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_735",
+    "statNm": "익명_충전소_735",
+    "addr": "익명_주소",
+    "lat": 37.474722601294125,
+    "lng": 127.02057253878155,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_736",
+    "statNm": "익명_충전소_736",
+    "addr": "익명_주소",
+    "lat": 37.50412855503795,
+    "lng": 127.03018942747126,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_737",
+    "statNm": "익명_충전소_737",
+    "addr": "익명_주소",
+    "lat": 37.519679103725764,
+    "lng": 127.03333134723145,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_738",
+    "statNm": "익명_충전소_738",
+    "addr": "익명_주소",
+    "lat": 37.52821317288939,
+    "lng": 126.94285486158441,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_739",
+    "statNm": "익명_충전소_739",
+    "addr": "익명_주소",
+    "lat": 37.57372917014295,
+    "lng": 126.91313728965929,
+    "useTime": "이용불가",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "개인용으로 이용불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_740",
+    "statNm": "익명_충전소_740",
+    "addr": "익명_주소",
+    "lat": 37.54265921632243,
+    "lng": 127.01186974406242,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_741",
+    "statNm": "익명_충전소_741",
+    "addr": "익명_주소",
+    "lat": 37.53536667243538,
+    "lng": 127.06210823673659,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_742",
+    "statNm": "익명_충전소_742",
+    "addr": "익명_주소",
+    "lat": 37.51691428905855,
+    "lng": 127.10191009279784,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_743",
+    "statNm": "익명_충전소_743",
+    "addr": "익명_주소",
+    "lat": 37.57031958215938,
+    "lng": 127.05968002304057,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_744",
+    "statNm": "익명_충전소_744",
+    "addr": "익명_주소",
+    "lat": 37.56394964283419,
+    "lng": 127.03197040180785,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_745",
+    "statNm": "익명_충전소_745",
+    "addr": "익명_주소",
+    "lat": 37.52794974473992,
+    "lng": 126.9973365375541,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_746",
+    "statNm": "익명_충전소_746",
+    "addr": "익명_주소",
+    "lat": 37.55197109026563,
+    "lng": 126.98968571720751,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_747",
+    "statNm": "익명_충전소_747",
+    "addr": "익명_주소",
+    "lat": 37.54568227130945,
+    "lng": 126.99803050139676,
+    "useTime": "24시간 이용가능/시설 상황에 따라 이용이 제한될 수 있습니다",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_748",
+    "statNm": "익명_충전소_748",
+    "addr": "익명_주소",
+    "lat": 37.5352338440702,
+    "lng": 126.86887783144446,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_749",
+    "statNm": "익명_충전소_749",
+    "addr": "익명_주소",
+    "lat": 37.58398898674074,
+    "lng": 127.04263374471242,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_750",
+    "statNm": "익명_충전소_750",
+    "addr": "익명_주소",
+    "lat": 37.58492610320861,
+    "lng": 127.06160752395805,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_751",
+    "statNm": "익명_충전소_751",
+    "addr": "익명_주소",
+    "lat": 37.609933771706224,
+    "lng": 127.07203040978027,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 9,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_752",
+    "statNm": "익명_충전소_752",
+    "addr": "익명_주소",
+    "lat": 37.478080115327145,
+    "lng": 126.98517499575404,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_753",
+    "statNm": "익명_충전소_753",
+    "addr": "익명_주소",
+    "lat": 37.54563240411531,
+    "lng": 127.0534856553949,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_754",
+    "statNm": "익명_충전소_754",
+    "addr": "익명_주소",
+    "lat": 37.5514132386728,
+    "lng": 126.9919514157911,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 320
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 320
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_755",
+    "statNm": "익명_충전소_755",
+    "addr": "익명_주소",
+    "lat": 37.58279354749882,
+    "lng": 127.04536844146872,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_756",
+    "statNm": "익명_충전소_756",
+    "addr": "익명_주소",
+    "lat": 37.57623360805623,
+    "lng": 126.99712856805215,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_757",
+    "statNm": "익명_충전소_757",
+    "addr": "익명_주소",
+    "lat": 37.490246476890874,
+    "lng": 127.01496589545957,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_758",
+    "statNm": "익명_충전소_758",
+    "addr": "익명_주소",
+    "lat": 37.58157640424468,
+    "lng": 127.05116997215094,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_759",
+    "statNm": "익명_충전소_759",
+    "addr": "익명_주소",
+    "lat": 37.50236510964805,
+    "lng": 127.0262685614464,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_760",
+    "statNm": "익명_충전소_760",
+    "addr": "익명_주소",
+    "lat": 37.58970717203762,
+    "lng": 127.05219975038875,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_761",
+    "statNm": "익명_충전소_761",
+    "addr": "익명_주소",
+    "lat": 37.6334300171342,
+    "lng": 127.01778074367432,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "시설 상황에 따라 사용 제한 될 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_762",
+    "statNm": "익명_충전소_762",
+    "addr": "익명_주소",
+    "lat": 37.60027873463741,
+    "lng": 126.8928864376227,
+    "useTime": "09:30~23:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_763",
+    "statNm": "익명_충전소_763",
+    "addr": "익명_주소",
+    "lat": 37.58973303084101,
+    "lng": 126.94460639642838,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "02-6733-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_764",
+    "statNm": "익명_충전소_764",
+    "addr": "익명_주소",
+    "lat": 37.48619353170832,
+    "lng": 126.90312218746382,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_765",
+    "statNm": "익명_충전소_765",
+    "addr": "익명_주소",
+    "lat": 37.49107652970702,
+    "lng": 126.98074201018073,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_766",
+    "statNm": "익명_충전소_766",
+    "addr": "익명_주소",
+    "lat": 37.58177805738084,
+    "lng": 126.90087024159729,
+    "useTime": "09:00 ~ 18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_767",
+    "statNm": "익명_충전소_767",
+    "addr": "익명_주소",
+    "lat": 37.51299031007705,
+    "lng": 127.05356177466072,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_768",
+    "statNm": "익명_충전소_768",
+    "addr": "익명_주소",
+    "lat": 37.514837210500204,
+    "lng": 126.93340776349363,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "21",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 200
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_769",
+    "statNm": "익명_충전소_769",
+    "addr": "익명_주소",
+    "lat": 37.52403193600504,
+    "lng": 127.05863479454143,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_770",
+    "statNm": "익명_충전소_770",
+    "addr": "익명_주소",
+    "lat": 37.59413993192007,
+    "lng": 126.98800807632519,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_771",
+    "statNm": "익명_충전소_771",
+    "addr": "익명_주소",
+    "lat": 37.575223776205824,
+    "lng": 126.93169364099693,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_772",
+    "statNm": "익명_충전소_772",
+    "addr": "익명_주소",
+    "lat": 37.54752139373711,
+    "lng": 127.05815985807452,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따라 주차비가 발생할 수 있음 ",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_773",
+    "statNm": "익명_충전소_773",
+    "addr": "익명_주소",
+    "lat": 37.54347413881799,
+    "lng": 127.08607336649446,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_774",
+    "statNm": "익명_충전소_774",
+    "addr": "익명_주소",
+    "lat": 37.5660289720097,
+    "lng": 127.03791235965238,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_775",
+    "statNm": "익명_충전소_775",
+    "addr": "익명_주소",
+    "lat": 37.55897864691206,
+    "lng": 126.97593076581744,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_776",
+    "statNm": "익명_충전소_776",
+    "addr": "익명_주소",
+    "lat": 37.59134493403199,
+    "lng": 127.00635830073352,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "21",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_777",
+    "statNm": "익명_충전소_777",
+    "addr": "익명_주소",
+    "lat": 37.53661663893305,
+    "lng": 127.06044568066764,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_778",
+    "statNm": "익명_충전소_778",
+    "addr": "익명_주소",
+    "lat": 37.48829024483766,
+    "lng": 127.03037226835403,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_779",
+    "statNm": "익명_충전소_779",
+    "addr": "익명_주소",
+    "lat": 37.583626476551466,
+    "lng": 127.07998770841249,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_780",
+    "statNm": "익명_충전소_780",
+    "addr": "익명_주소",
+    "lat": 37.48560715093256,
+    "lng": 127.02839917144986,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_781",
+    "statNm": "익명_충전소_781",
+    "addr": "익명_주소",
+    "lat": 37.50716810038313,
+    "lng": 126.99660047374961,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_782",
+    "statNm": "익명_충전소_782",
+    "addr": "익명_주소",
+    "lat": 37.61390757989558,
+    "lng": 127.05221960961562,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 9,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_783",
+    "statNm": "익명_충전소_783",
+    "addr": "익명_주소",
+    "lat": 37.61016960952412,
+    "lng": 127.0510944587037,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_784",
+    "statNm": "익명_충전소_784",
+    "addr": "익명_주소",
+    "lat": 37.58646003595829,
+    "lng": 127.06248595651367,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_785",
+    "statNm": "익명_충전소_785",
+    "addr": "익명_주소",
+    "lat": 37.52129633259229,
+    "lng": 127.10043702272684,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_786",
+    "statNm": "익명_충전소_786",
+    "addr": "익명_주소",
+    "lat": 37.53467743111503,
+    "lng": 126.92638938299999,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "032-207-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": ".",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_787",
+    "statNm": "익명_충전소_787",
+    "addr": "익명_주소",
+    "lat": 37.59520812172986,
+    "lng": 126.87075018283727,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 3
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_788",
+    "statNm": "익명_충전소_788",
+    "addr": "익명_주소",
+    "lat": 37.61649391131747,
+    "lng": 126.9416365233557,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 3
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 3
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_789",
+    "statNm": "익명_충전소_789",
+    "addr": "익명_주소",
+    "lat": 37.57044697018042,
+    "lng": 126.98034508558275,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_790",
+    "statNm": "익명_충전소_790",
+    "addr": "익명_주소",
+    "lat": 37.59756711396659,
+    "lng": 127.04615000629519,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_791",
+    "statNm": "익명_충전소_791",
+    "addr": "익명_주소",
+    "lat": 37.612785565773315,
+    "lng": 126.9726291633039,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 18,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "14",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "15",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "16",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "17",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "18",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_792",
+    "statNm": "익명_충전소_792",
+    "addr": "익명_주소",
+    "lat": 37.5878671087091,
+    "lng": 126.89913887572348,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_793",
+    "statNm": "익명_충전소_793",
+    "addr": "익명_주소",
+    "lat": 37.53551721486101,
+    "lng": 127.05821947473964,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_794",
+    "statNm": "익명_충전소_794",
+    "addr": "익명_주소",
+    "lat": 37.59015375971326,
+    "lng": 127.05929818261167,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_795",
+    "statNm": "익명_충전소_795",
+    "addr": "익명_주소",
+    "lat": 37.5969238612045,
+    "lng": 127.02355140366203,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_796",
+    "statNm": "익명_충전소_796",
+    "addr": "익명_주소",
+    "lat": 37.48672958077841,
+    "lng": 126.95333355269418,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_797",
+    "statNm": "익명_충전소_797",
+    "addr": "익명_주소",
+    "lat": 37.57937409134226,
+    "lng": 127.06812662574498,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_798",
+    "statNm": "익명_충전소_798",
+    "addr": "익명_주소",
+    "lat": 37.59931457689841,
+    "lng": 127.08382543283649,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_799",
+    "statNm": "익명_충전소_799",
+    "addr": "익명_주소",
+    "lat": 37.49567952485448,
+    "lng": 126.98100518338272,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_800",
+    "statNm": "익명_충전소_800",
+    "addr": "익명_주소",
+    "lat": 37.61483414503693,
+    "lng": 127.08626230717171,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_801",
+    "statNm": "익명_충전소_801",
+    "addr": "익명_주소",
+    "lat": 37.54456370466655,
+    "lng": 127.02524247047376,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_802",
+    "statNm": "익명_충전소_802",
+    "addr": "익명_주소",
+    "lat": 37.571004203591514,
+    "lng": 127.01964628697854,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "누구나 사용가능",
+    "note": "24시간 이용가능",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_803",
+    "statNm": "익명_충전소_803",
+    "addr": "익명_주소",
+    "lat": 37.505972434187335,
+    "lng": 127.01586373134916,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_804",
+    "statNm": "익명_충전소_804",
+    "addr": "익명_주소",
+    "lat": 37.47702711202586,
+    "lng": 126.97304128246908,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "거주자외 출입제한",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_805",
+    "statNm": "익명_충전소_805",
+    "addr": "익명_주소",
+    "lat": 37.627536079453,
+    "lng": 127.05954063818736,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 10,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_806",
+    "statNm": "익명_충전소_806",
+    "addr": "익명_주소",
+    "lat": 37.53892620326511,
+    "lng": 127.04124141467028,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_807",
+    "statNm": "익명_충전소_807",
+    "addr": "익명_주소",
+    "lat": 37.551703078674855,
+    "lng": 127.05903496023143,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_808",
+    "statNm": "익명_충전소_808",
+    "addr": "익명_주소",
+    "lat": 37.592705320768054,
+    "lng": 127.04190557743628,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_809",
+    "statNm": "익명_충전소_809",
+    "addr": "익명_주소",
+    "lat": 37.60673538861916,
+    "lng": 127.01370660794086,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_810",
+    "statNm": "익명_충전소_810",
+    "addr": "익명_주소",
+    "lat": 37.50230744246522,
+    "lng": 127.05214668212395,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_811",
+    "statNm": "익명_충전소_811",
+    "addr": "익명_주소",
+    "lat": 37.621602709150174,
+    "lng": 127.0771251236375,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "Y(부분제한)",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_812",
+    "statNm": "익명_충전소_812",
+    "addr": "익명_주소",
+    "lat": 37.53324006986001,
+    "lng": 126.92750280522381,
+    "useTime": "05:00~00:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "23",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "35",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "37",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "42",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_813",
+    "statNm": "익명_충전소_813",
+    "addr": "익명_주소",
+    "lat": 37.613447031246494,
+    "lng": 127.07928197207775,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "Y(부분제한)",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_814",
+    "statNm": "익명_충전소_814",
+    "addr": "익명_주소",
+    "lat": 37.58167359952084,
+    "lng": 126.97108777853337,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_815",
+    "statNm": "익명_충전소_815",
+    "addr": "익명_주소",
+    "lat": 37.538365751098326,
+    "lng": 126.92607817528636,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_816",
+    "statNm": "익명_충전소_816",
+    "addr": "익명_주소",
+    "lat": 37.56152433547092,
+    "lng": 127.09703576140673,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_817",
+    "statNm": "익명_충전소_817",
+    "addr": "익명_주소",
+    "lat": 37.607957496079386,
+    "lng": 127.10666752509654,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_818",
+    "statNm": "익명_충전소_818",
+    "addr": "익명_주소",
+    "lat": 37.59331408623152,
+    "lng": 127.03540891707492,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_819",
+    "statNm": "익명_충전소_819",
+    "addr": "익명_주소",
+    "lat": 37.56243374237853,
+    "lng": 127.01270521206256,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_820",
+    "statNm": "익명_충전소_820",
+    "addr": "익명_주소",
+    "lat": 37.56179272431984,
+    "lng": 127.01252542778738,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_821",
+    "statNm": "익명_충전소_821",
+    "addr": "익명_주소",
+    "lat": 37.5808496434601,
+    "lng": 127.0099275494165,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "Y(부분제한)",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_822",
+    "statNm": "익명_충전소_822",
+    "addr": "익명_주소",
+    "lat": 37.60958132519621,
+    "lng": 126.92489390884151,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_823",
+    "statNm": "익명_충전소_823",
+    "addr": "익명_주소",
+    "lat": 37.613426350287696,
+    "lng": 127.05367000623457,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_824",
+    "statNm": "익명_충전소_824",
+    "addr": "익명_주소",
+    "lat": 37.61186581532109,
+    "lng": 127.0934433237721,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "Y(부분제한)",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_825",
+    "statNm": "익명_충전소_825",
+    "addr": "익명_주소",
+    "lat": 37.60677072769133,
+    "lng": 127.08872994247912,
+    "useTime": "05:00 ~ 23:00 개방",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_826",
+    "statNm": "익명_충전소_826",
+    "addr": "익명_주소",
+    "lat": 37.556757932017646,
+    "lng": 127.08522609907418,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_827",
+    "statNm": "익명_충전소_827",
+    "addr": "익명_주소",
+    "lat": 37.571016152965186,
+    "lng": 127.05005198586815,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 전용",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_828",
+    "statNm": "익명_충전소_828",
+    "addr": "익명_주소",
+    "lat": 37.55489650862645,
+    "lng": 126.92893514722053,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_829",
+    "statNm": "익명_충전소_829",
+    "addr": "익명_주소",
+    "lat": 37.5381523569857,
+    "lng": 127.08701550904874,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 전용",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_830",
+    "statNm": "익명_충전소_830",
+    "addr": "익명_주소",
+    "lat": 37.558839662215064,
+    "lng": 127.00006399408628,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_831",
+    "statNm": "익명_충전소_831",
+    "addr": "익명_주소",
+    "lat": 37.53746948668318,
+    "lng": 126.93166138170123,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 18,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "14",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "15",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "16",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "17",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "18",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_832",
+    "statNm": "익명_충전소_832",
+    "addr": "익명_주소",
+    "lat": 37.644105140742035,
+    "lng": 127.04321366760682,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "Y(부분제한)",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_833",
+    "statNm": "익명_충전소_833",
+    "addr": "익명_주소",
+    "lat": 37.5844666544133,
+    "lng": 127.02689719781547,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_834",
+    "statNm": "익명_충전소_834",
+    "addr": "익명_주소",
+    "lat": 37.52593029083321,
+    "lng": 127.01389970813176,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_835",
+    "statNm": "익명_충전소_835",
+    "addr": "익명_주소",
+    "lat": 37.64171679476615,
+    "lng": 127.05545233548688,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_836",
+    "statNm": "익명_충전소_836",
+    "addr": "익명_주소",
+    "lat": 37.570861947325035,
+    "lng": 126.85698733212693,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_837",
+    "statNm": "익명_충전소_837",
+    "addr": "익명_주소",
+    "lat": 37.59496471453266,
+    "lng": 126.91502381033384,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 출입불가",
+    "note": "외부인 출입불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_838",
+    "statNm": "익명_충전소_838",
+    "addr": "익명_주소",
+    "lat": 37.61751213779232,
+    "lng": 127.02667328889599,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "1",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_839",
+    "statNm": "익명_충전소_839",
+    "addr": "익명_주소",
+    "lat": 37.58460370567864,
+    "lng": 127.02307795891122,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "11",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 200
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_840",
+    "statNm": "익명_충전소_840",
+    "addr": "익명_주소",
+    "lat": 37.573630884705274,
+    "lng": 127.07393611881693,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_841",
+    "statNm": "익명_충전소_841",
+    "addr": "익명_주소",
+    "lat": 37.53362878676529,
+    "lng": 127.02820785917486,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_842",
+    "statNm": "익명_충전소_842",
+    "addr": "익명_주소",
+    "lat": 37.58451891558072,
+    "lng": 127.05978794294731,
+    "useTime": "09~18시 개방",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "21",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_843",
+    "statNm": "익명_충전소_843",
+    "addr": "익명_주소",
+    "lat": 37.562216790654404,
+    "lng": 127.04689081332022,
+    "useTime": "10:00~23:59/2째,4째주 일요일 이용x",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 15,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "14",
+        "chgerType": "08",
+        "stat": "2",
+        "output": 30
+      },
+      {
+        "chgerId": "15",
+        "chgerType": "08",
+        "stat": "3",
+        "output": 30
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_844",
+    "statNm": "익명_충전소_844",
+    "addr": "익명_주소",
+    "lat": 37.58754392910207,
+    "lng": 127.06644004308532,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_845",
+    "statNm": "익명_충전소_845",
+    "addr": "익명_주소",
+    "lat": 37.60468554817401,
+    "lng": 126.94177771556744,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_846",
+    "statNm": "익명_충전소_846",
+    "addr": "익명_주소",
+    "lat": 37.57207846130702,
+    "lng": 127.00176928937849,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "시설 상황에 따라 사용 제한 될 수 있음",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_847",
+    "statNm": "익명_충전소_847",
+    "addr": "익명_주소",
+    "lat": 37.53805445911192,
+    "lng": 127.05857303813336,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_848",
+    "statNm": "익명_충전소_848",
+    "addr": "익명_주소",
+    "lat": 37.560602973222785,
+    "lng": 127.03205597264247,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_849",
+    "statNm": "익명_충전소_849",
+    "addr": "익명_주소",
+    "lat": 37.63735765513769,
+    "lng": 127.04645500269675,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "Y(부분제한)",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_850",
+    "statNm": "익명_충전소_850",
+    "addr": "익명_주소",
+    "lat": 37.53665043000075,
+    "lng": 127.04596221316694,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_851",
+    "statNm": "익명_충전소_851",
+    "addr": "익명_주소",
+    "lat": 37.63742153049429,
+    "lng": 126.98917809194467,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "Y(부분제한)",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_852",
+    "statNm": "익명_충전소_852",
+    "addr": "익명_주소",
+    "lat": 37.509781420203474,
+    "lng": 127.00372731721724,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_853",
+    "statNm": "익명_충전소_853",
+    "addr": "익명_주소",
+    "lat": 37.643316317499554,
+    "lng": 127.09226655872556,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_854",
+    "statNm": "익명_충전소_854",
+    "addr": "익명_주소",
+    "lat": 37.50709887952639,
+    "lng": 126.90367738684823,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "누구나 사용 가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_855",
+    "statNm": "익명_충전소_855",
+    "addr": "익명_주소",
+    "lat": 37.54658689172512,
+    "lng": 126.996194885612,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "누구나 사용 가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_856",
+    "statNm": "익명_충전소_856",
+    "addr": "익명_주소",
+    "lat": 37.60679860165454,
+    "lng": 127.00105553203325,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "05",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_857",
+    "statNm": "익명_충전소_857",
+    "addr": "익명_주소",
+    "lat": 37.52497208300771,
+    "lng": 127.00213787131692,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_858",
+    "statNm": "익명_충전소_858",
+    "addr": "익명_주소",
+    "lat": 37.550908674768685,
+    "lng": 127.10174518265086,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_859",
+    "statNm": "익명_충전소_859",
+    "addr": "익명_주소",
+    "lat": 37.60088506858808,
+    "lng": 127.10492437484751,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_860",
+    "statNm": "익명_충전소_860",
+    "addr": "익명_주소",
+    "lat": 37.57112443954884,
+    "lng": 127.02522784157081,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "Y(부분제한)",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_861",
+    "statNm": "익명_충전소_861",
+    "addr": "익명_주소",
+    "lat": 37.49275198187142,
+    "lng": 126.87685972316075,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "52",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_862",
+    "statNm": "익명_충전소_862",
+    "addr": "익명_주소",
+    "lat": 37.59086688284164,
+    "lng": 127.0873559099412,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_863",
+    "statNm": "익명_충전소_863",
+    "addr": "익명_주소",
+    "lat": 37.62980383294514,
+    "lng": 127.06233751512713,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 9,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_864",
+    "statNm": "익명_충전소_864",
+    "addr": "익명_주소",
+    "lat": 37.50455384440197,
+    "lng": 127.07415887428743,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_865",
+    "statNm": "익명_충전소_865",
+    "addr": "익명_주소",
+    "lat": 37.53147586371088,
+    "lng": 127.08740128614707,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_866",
+    "statNm": "익명_충전소_866",
+    "addr": "익명_주소",
+    "lat": 37.51850970744387,
+    "lng": 127.04072364898276,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_867",
+    "statNm": "익명_충전소_867",
+    "addr": "익명_주소",
+    "lat": 37.54157349956388,
+    "lng": 127.01256125829977,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_868",
+    "statNm": "익명_충전소_868",
+    "addr": "익명_주소",
+    "lat": 37.57627142440731,
+    "lng": 126.90408662735109,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "21",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "23",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "24",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_869",
+    "statNm": "익명_충전소_869",
+    "addr": "익명_주소",
+    "lat": 37.620111629573586,
+    "lng": 126.99969802096732,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "1",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_870",
+    "statNm": "익명_충전소_870",
+    "addr": "익명_주소",
+    "lat": 37.656138158779214,
+    "lng": 126.99050583400387,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "시설 상황에 따라 사용 제한 될 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_871",
+    "statNm": "익명_충전소_871",
+    "addr": "익명_주소",
+    "lat": 37.5361147786083,
+    "lng": 126.9416459933518,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따라 주차비가 발생할 수 있음 ",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_872",
+    "statNm": "익명_충전소_872",
+    "addr": "익명_주소",
+    "lat": 37.527760015033365,
+    "lng": 126.9474503918353,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_873",
+    "statNm": "익명_충전소_873",
+    "addr": "익명_주소",
+    "lat": 37.532449040075704,
+    "lng": 127.00570332277647,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "화장실 위치 : 충전소에서 정성옥 가는 입구 왼편, 비밀번호 : 4685*",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 180
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 180
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_874",
+    "statNm": "익명_충전소_874",
+    "addr": "익명_주소",
+    "lat": 37.633771145918836,
+    "lng": 126.90925148459053,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "택시차고지 차량이 다수로 이용이 어려울수 있음",
+    "note": "",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_875",
+    "statNm": "익명_충전소_875",
+    "addr": "익명_주소",
+    "lat": 37.6372050256418,
+    "lng": 126.94602842188824,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_876",
+    "statNm": "익명_충전소_876",
+    "addr": "익명_주소",
+    "lat": 37.527709184209066,
+    "lng": 127.02471466799993,
+    "useTime": "24시간 이용가능/시설 상황에 따라 이용이 제한될 수 있습니다",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_877",
+    "statNm": "익명_충전소_877",
+    "addr": "익명_주소",
+    "lat": 37.482204476752756,
+    "lng": 126.94018514879129,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 14
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 14
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_878",
+    "statNm": "익명_충전소_878",
+    "addr": "익명_주소",
+    "lat": 37.54021620397143,
+    "lng": 127.06867347145814,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "임직원 외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_879",
+    "statNm": "익명_충전소_879",
+    "addr": "익명_주소",
+    "lat": 37.57666091583574,
+    "lng": 126.96145143353372,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_880",
+    "statNm": "익명_충전소_880",
+    "addr": "익명_주소",
+    "lat": 37.56658505281513,
+    "lng": 127.04853957587773,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "24시간 누구나 개방(무료주차) 충전소",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_881",
+    "statNm": "익명_충전소_881",
+    "addr": "익명_주소",
+    "lat": 37.49568992573981,
+    "lng": 126.96392772859006,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "외부인 출입불가",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "06",
+        "stat": "3",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_882",
+    "statNm": "익명_충전소_882",
+    "addr": "익명_주소",
+    "lat": 37.52331552437054,
+    "lng": 127.0394352397026,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_883",
+    "statNm": "익명_충전소_883",
+    "addr": "익명_주소",
+    "lat": 37.65461277581888,
+    "lng": 126.95350789012176,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_884",
+    "statNm": "익명_충전소_884",
+    "addr": "익명_주소",
+    "lat": 37.54858663449257,
+    "lng": 127.00085938874004,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_885",
+    "statNm": "익명_충전소_885",
+    "addr": "익명_주소",
+    "lat": 37.57871358853774,
+    "lng": 127.07380160873602,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_886",
+    "statNm": "익명_충전소_886",
+    "addr": "익명_주소",
+    "lat": 37.5837993701587,
+    "lng": 127.01454455404912,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_887",
+    "statNm": "익명_충전소_887",
+    "addr": "익명_주소",
+    "lat": 37.62214073415481,
+    "lng": 126.85858844515238,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_888",
+    "statNm": "익명_충전소_888",
+    "addr": "익명_주소",
+    "lat": 37.47748733738979,
+    "lng": 126.90050844524232,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "Y(부분제한)",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_889",
+    "statNm": "익명_충전소_889",
+    "addr": "익명_주소",
+    "lat": 37.49089500832824,
+    "lng": 126.99463050772064,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "Y(부분제한)",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_890",
+    "statNm": "익명_충전소_890",
+    "addr": "익명_주소",
+    "lat": 37.637623139055734,
+    "lng": 126.90158945255561,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_891",
+    "statNm": "익명_충전소_891",
+    "addr": "익명_주소",
+    "lat": 37.520698800180746,
+    "lng": 126.98484279601736,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_892",
+    "statNm": "익명_충전소_892",
+    "addr": "익명_주소",
+    "lat": 37.48239598276113,
+    "lng": 126.90387446760842,
+    "useTime": "부분 비개방",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따란 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_893",
+    "statNm": "익명_충전소_893",
+    "addr": "익명_주소",
+    "lat": 37.52949162235455,
+    "lng": 127.0657525165812,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민 전용",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_894",
+    "statNm": "익명_충전소_894",
+    "addr": "익명_주소",
+    "lat": 37.546753401838394,
+    "lng": 127.03306549688608,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_895",
+    "statNm": "익명_충전소_895",
+    "addr": "익명_주소",
+    "lat": 37.58846656733126,
+    "lng": 127.01694326616258,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "05",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_896",
+    "statNm": "익명_충전소_896",
+    "addr": "익명_주소",
+    "lat": 37.582747174342344,
+    "lng": 127.01862664347402,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_897",
+    "statNm": "익명_충전소_897",
+    "addr": "익명_주소",
+    "lat": 37.57831849957673,
+    "lng": 127.0989301353722,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_898",
+    "statNm": "익명_충전소_898",
+    "addr": "익명_주소",
+    "lat": 37.597572884820444,
+    "lng": 127.01926302165023,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_899",
+    "statNm": "익명_충전소_899",
+    "addr": "익명_주소",
+    "lat": 37.52762743148979,
+    "lng": 126.88822273202375,
+    "useTime": "24시간 이용가능, 5부제 해당 차량 출입통제",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "4",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_900",
+    "statNm": "익명_충전소_900",
+    "addr": "익명_주소",
+    "lat": 37.51438708283295,
+    "lng": 126.9336845627779,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_901",
+    "statNm": "익명_충전소_901",
+    "addr": "익명_주소",
+    "lat": 37.548338311591515,
+    "lng": 127.04201062638879,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "입주민외 이용제한 있을 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_902",
+    "statNm": "익명_충전소_902",
+    "addr": "익명_주소",
+    "lat": 37.622682356617744,
+    "lng": 126.9865793082803,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_903",
+    "statNm": "익명_충전소_903",
+    "addr": "익명_주소",
+    "lat": 37.56831422188482,
+    "lng": 126.94308904481261,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 10,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_904",
+    "statNm": "익명_충전소_904",
+    "addr": "익명_주소",
+    "lat": 37.51613234286205,
+    "lng": 126.9389547759662,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "5",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "91",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_905",
+    "statNm": "익명_충전소_905",
+    "addr": "익명_주소",
+    "lat": 37.49279284042951,
+    "lng": 126.94749824647783,
+    "useTime": "24시간 이용가능(외부인 미개방)",
+    "busiNm": "익명_사업자",
+    "busiCall": "이XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "직원 전용, 외부인 사용불가",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_906",
+    "statNm": "익명_충전소_906",
+    "addr": "익명_주소",
+    "lat": 37.46833950958869,
+    "lng": 126.96557646335464,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_907",
+    "statNm": "익명_충전소_907",
+    "addr": "익명_주소",
+    "lat": 37.494701709471414,
+    "lng": 126.96082712656583,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_908",
+    "statNm": "익명_충전소_908",
+    "addr": "익명_주소",
+    "lat": 37.5568391157001,
+    "lng": 127.0883954131326,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_909",
+    "statNm": "익명_충전소_909",
+    "addr": "익명_주소",
+    "lat": 37.62308838743316,
+    "lng": 126.98832563661914,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_910",
+    "statNm": "익명_충전소_910",
+    "addr": "익명_주소",
+    "lat": 37.47981448027707,
+    "lng": 126.99615881317858,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_911",
+    "statNm": "익명_충전소_911",
+    "addr": "익명_주소",
+    "lat": 37.499925795718,
+    "lng": 126.98906479396436,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_912",
+    "statNm": "익명_충전소_912",
+    "addr": "익명_주소",
+    "lat": 37.53271215708789,
+    "lng": 127.0341524682346,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 9,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_913",
+    "statNm": "익명_충전소_913",
+    "addr": "익명_주소",
+    "lat": 37.48394614241905,
+    "lng": 127.04829930136474,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_914",
+    "statNm": "익명_충전소_914",
+    "addr": "익명_주소",
+    "lat": 37.470322595918574,
+    "lng": 127.01772403473103,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_915",
+    "statNm": "익명_충전소_915",
+    "addr": "익명_주소",
+    "lat": 37.533355935960905,
+    "lng": 127.03260966074843,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "거주자 외 출입이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_916",
+    "statNm": "익명_충전소_916",
+    "addr": "익명_주소",
+    "lat": 37.528825576003356,
+    "lng": 126.96124433309971,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 32,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "14",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "15",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "16",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "17",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "18",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "19",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "20",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "21",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "23",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "24",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "25",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "26",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "27",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "28",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "29",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "30",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "31",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "32",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_917",
+    "statNm": "익명_충전소_917",
+    "addr": "익명_주소",
+    "lat": 37.507508504429424,
+    "lng": 127.10407442102311,
+    "useTime": "외부인 출입금지",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 출입/사용불가 이용제한",
+    "note": "외부인 출입/사용불가 이용제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_918",
+    "statNm": "익명_충전소_918",
+    "addr": "익명_주소",
+    "lat": 37.527234325270975,
+    "lng": 127.01714236380388,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따라 주차비가 발생할 수 있음",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_919",
+    "statNm": "익명_충전소_919",
+    "addr": "익명_주소",
+    "lat": 37.628151808944246,
+    "lng": 126.91340675330305,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자 외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_920",
+    "statNm": "익명_충전소_920",
+    "addr": "익명_주소",
+    "lat": 37.5543912029718,
+    "lng": 127.0375156157682,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "21",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 200
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_921",
+    "statNm": "익명_충전소_921",
+    "addr": "익명_주소",
+    "lat": 37.58785841481272,
+    "lng": 127.09324788923139,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1644-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_922",
+    "statNm": "익명_충전소_922",
+    "addr": "익명_주소",
+    "lat": 37.59259012526923,
+    "lng": 127.09823224734306,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 7,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_923",
+    "statNm": "익명_충전소_923",
+    "addr": "익명_주소",
+    "lat": 37.588449068032254,
+    "lng": 126.85728083645108,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 20,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "1",
+        "output": 200
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "1",
+        "output": 200
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "14",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "15",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "16",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "17",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "18",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "19",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      },
+      {
+        "chgerId": "20",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 11
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_924",
+    "statNm": "익명_충전소_924",
+    "addr": "익명_주소",
+    "lat": 37.59278337308728,
+    "lng": 127.09038348252199,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_925",
+    "statNm": "익명_충전소_925",
+    "addr": "익명_주소",
+    "lat": 37.56213920835175,
+    "lng": 127.05407039150812,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따라 주차비가 발생할 수 있음 ",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "1",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_926",
+    "statNm": "익명_충전소_926",
+    "addr": "익명_주소",
+    "lat": 37.53758091092766,
+    "lng": 126.9459884440081,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_927",
+    "statNm": "익명_충전소_927",
+    "addr": "익명_주소",
+    "lat": 37.53418121948659,
+    "lng": 127.02053915542506,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1600-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_928",
+    "statNm": "익명_충전소_928",
+    "addr": "익명_주소",
+    "lat": 37.5077718026504,
+    "lng": 126.95986035903361,
+    "useTime": "07:00-22:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "9",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_929",
+    "statNm": "익명_충전소_929",
+    "addr": "익명_주소",
+    "lat": 37.52563269196183,
+    "lng": 127.016074756437,
+    "useTime": "외부인 출입금지",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 출입/사용불가 이용제한",
+    "note": "외부인 출입/사용불가 이용제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_930",
+    "statNm": "익명_충전소_930",
+    "addr": "익명_주소",
+    "lat": 37.54267382516993,
+    "lng": 127.04854034952513,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_931",
+    "statNm": "익명_충전소_931",
+    "addr": "익명_주소",
+    "lat": 37.508269511712804,
+    "lng": 126.9314532182398,
+    "useTime": "09:00 ~ 18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "52",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_932",
+    "statNm": "익명_충전소_932",
+    "addr": "익명_주소",
+    "lat": 37.50475718112359,
+    "lng": 126.96147063500416,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "24시간 이용가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_933",
+    "statNm": "익명_충전소_933",
+    "addr": "익명_주소",
+    "lat": 37.479554058708494,
+    "lng": 127.00127654380803,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_934",
+    "statNm": "익명_충전소_934",
+    "addr": "익명_주소",
+    "lat": 37.621026220226085,
+    "lng": 126.93438770995107,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_935",
+    "statNm": "익명_충전소_935",
+    "addr": "익명_주소",
+    "lat": 37.58493185729894,
+    "lng": 126.87743752462762,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 10,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "14",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "15",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_936",
+    "statNm": "익명_충전소_936",
+    "addr": "익명_주소",
+    "lat": 37.60752887838429,
+    "lng": 126.93105223044462,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 10,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "14",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "15",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_937",
+    "statNm": "익명_충전소_937",
+    "addr": "익명_주소",
+    "lat": 37.59689164873307,
+    "lng": 127.06624388026657,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "05",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "05",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_938",
+    "statNm": "익명_충전소_938",
+    "addr": "익명_주소",
+    "lat": 37.630688085529854,
+    "lng": 127.0222947777737,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_939",
+    "statNm": "익명_충전소_939",
+    "addr": "익명_주소",
+    "lat": 37.54827009089824,
+    "lng": 127.04682999094081,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자 외 출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_940",
+    "statNm": "익명_충전소_940",
+    "addr": "익명_주소",
+    "lat": 37.53113828602257,
+    "lng": 127.00641163219241,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "직원 외 이용불가",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_941",
+    "statNm": "익명_충전소_941",
+    "addr": "익명_주소",
+    "lat": 37.52455925772868,
+    "lng": 126.95291946987936,
+    "useTime": "비개방",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "시설 상황에 따라 사용 제한 될 수 있음",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_942",
+    "statNm": "익명_충전소_942",
+    "addr": "익명_주소",
+    "lat": 37.51239160453486,
+    "lng": 126.96036460104581,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 14,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "14",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_943",
+    "statNm": "익명_충전소_943",
+    "addr": "익명_주소",
+    "lat": 37.62492178559169,
+    "lng": 126.85382078041883,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_944",
+    "statNm": "익명_충전소_944",
+    "addr": "익명_주소",
+    "lat": 37.60904999989389,
+    "lng": 126.99837484859906,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "043-260-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_945",
+    "statNm": "익명_충전소_945",
+    "addr": "익명_주소",
+    "lat": 37.480755099268826,
+    "lng": 127.00620881494062,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_946",
+    "statNm": "익명_충전소_946",
+    "addr": "익명_주소",
+    "lat": 37.62987326378327,
+    "lng": 126.96150955324677,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만이용가능",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_947",
+    "statNm": "익명_충전소_947",
+    "addr": "익명_주소",
+    "lat": 37.52147122913948,
+    "lng": 126.912415279323,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_948",
+    "statNm": "익명_충전소_948",
+    "addr": "익명_주소",
+    "lat": 37.534399961521224,
+    "lng": 126.88504101150303,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_949",
+    "statNm": "익명_충전소_949",
+    "addr": "익명_주소",
+    "lat": 37.55596623096228,
+    "lng": 126.8600011631695,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_950",
+    "statNm": "익명_충전소_950",
+    "addr": "익명_주소",
+    "lat": 37.543574802430356,
+    "lng": 127.08077926772445,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": true,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음.",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_951",
+    "statNm": "익명_충전소_951",
+    "addr": "익명_주소",
+    "lat": 37.584953299698526,
+    "lng": 126.8786849609079,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_952",
+    "statNm": "익명_충전소_952",
+    "addr": "익명_주소",
+    "lat": 37.502691634888144,
+    "lng": 126.95533857353178,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_953",
+    "statNm": "익명_충전소_953",
+    "addr": "익명_주소",
+    "lat": 37.627716654607674,
+    "lng": 127.0601305456987,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_954",
+    "statNm": "익명_충전소_954",
+    "addr": "익명_주소",
+    "lat": 37.56545878121213,
+    "lng": 126.94589114853723,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_955",
+    "statNm": "익명_충전소_955",
+    "addr": "익명_주소",
+    "lat": 37.56743207113244,
+    "lng": 126.92695003443683,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "21",
+        "chgerType": "04",
+        "stat": "3",
+        "output": 200
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "23",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "24",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "25",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "26",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_956",
+    "statNm": "익명_충전소_956",
+    "addr": "익명_주소",
+    "lat": 37.56518760042052,
+    "lng": 127.00562867722368,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_957",
+    "statNm": "익명_충전소_957",
+    "addr": "익명_주소",
+    "lat": 37.48241089036175,
+    "lng": 126.95076102168241,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_958",
+    "statNm": "익명_충전소_958",
+    "addr": "익명_주소",
+    "lat": 37.61738481263999,
+    "lng": 126.92235984863538,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "21",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "22",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_959",
+    "statNm": "익명_충전소_959",
+    "addr": "익명_주소",
+    "lat": 37.5232920321185,
+    "lng": 126.8773256244127,
+    "useTime": "09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_960",
+    "statNm": "익명_충전소_960",
+    "addr": "익명_주소",
+    "lat": 37.57043085409889,
+    "lng": 126.95479398028773,
+    "useTime": "외부인 출입금지",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 출입/사용불가 이용제한",
+    "note": "외부인 출입/사용불가 이용제한",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_961",
+    "statNm": "익명_충전소_961",
+    "addr": "익명_주소",
+    "lat": 37.55680470699045,
+    "lng": 127.01444543511604,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_962",
+    "statNm": "익명_충전소_962",
+    "addr": "익명_주소",
+    "lat": 37.571099632214924,
+    "lng": 126.8823830857177,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_963",
+    "statNm": "익명_충전소_963",
+    "addr": "익명_주소",
+    "lat": 37.51059259903244,
+    "lng": 126.98765993928129,
+    "useTime": "평일 07:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "주말 및 공휴일 미개방",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "04",
+        "stat": "9",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_964",
+    "statNm": "익명_충전소_964",
+    "addr": "익명_주소",
+    "lat": 37.551933886060795,
+    "lng": 126.9031655111466,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_965",
+    "statNm": "익명_충전소_965",
+    "addr": "익명_주소",
+    "lat": 37.4839916973164,
+    "lng": 126.9851872939124,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "05",
+        "stat": "9",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_966",
+    "statNm": "익명_충전소_966",
+    "addr": "익명_주소",
+    "lat": 37.602956776049325,
+    "lng": 127.05252713132805,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_967",
+    "statNm": "익명_충전소_967",
+    "addr": "익명_주소",
+    "lat": 37.65772759259543,
+    "lng": 127.01475529509851,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1588-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "05",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_968",
+    "statNm": "익명_충전소_968",
+    "addr": "익명_주소",
+    "lat": 37.60749610109416,
+    "lng": 126.95905752370666,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_969",
+    "statNm": "익명_충전소_969",
+    "addr": "익명_주소",
+    "lat": 37.54585298216901,
+    "lng": 127.01765998593079,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_970",
+    "statNm": "익명_충전소_970",
+    "addr": "익명_주소",
+    "lat": 37.59903574147622,
+    "lng": 126.88255520691891,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 출입불가",
+    "note": "누구나 사용 가능",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_971",
+    "statNm": "익명_충전소_971",
+    "addr": "익명_주소",
+    "lat": 37.47483036958252,
+    "lng": 127.05126019157939,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_972",
+    "statNm": "익명_충전소_972",
+    "addr": "익명_주소",
+    "lat": 37.604317953499674,
+    "lng": 127.05010194493546,
+    "useTime": "평일07:00~22:00,토일 09:00~18:00",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_973",
+    "statNm": "익명_충전소_973",
+    "addr": "익명_주소",
+    "lat": 37.470484406886726,
+    "lng": 126.90687625244333,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_974",
+    "statNm": "익명_충전소_974",
+    "addr": "익명_주소",
+    "lat": 37.479470238687504,
+    "lng": 126.96248755634909,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_975",
+    "statNm": "익명_충전소_975",
+    "addr": "익명_주소",
+    "lat": 37.51704261925119,
+    "lng": 126.89916298865994,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_976",
+    "statNm": "익명_충전소_976",
+    "addr": "익명_주소",
+    "lat": 37.486003503049396,
+    "lng": 127.05925089832135,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_977",
+    "statNm": "익명_충전소_977",
+    "addr": "익명_주소",
+    "lat": 37.50408015480719,
+    "lng": 127.00441978192984,
+    "useTime": "09:00~18:00(입주민 외 이용불가)",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_978",
+    "statNm": "익명_충전소_978",
+    "addr": "익명_주소",
+    "lat": 37.49784277686859,
+    "lng": 127.10267378193672,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_979",
+    "statNm": "익명_충전소_979",
+    "addr": "익명_주소",
+    "lat": 37.518033352723265,
+    "lng": 126.92333436875424,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 3,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_980",
+    "statNm": "익명_충전소_980",
+    "addr": "익명_주소",
+    "lat": 37.592239651297014,
+    "lng": 127.0088454593405,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_981",
+    "statNm": "익명_충전소_981",
+    "addr": "익명_주소",
+    "lat": 37.590941079348354,
+    "lng": 127.02372844710055,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_982",
+    "statNm": "익명_충전소_982",
+    "addr": "익명_주소",
+    "lat": 37.54872415122828,
+    "lng": 127.07779806811293,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "12",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "13",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_983",
+    "statNm": "익명_충전소_983",
+    "addr": "익명_주소",
+    "lat": 37.505927905333984,
+    "lng": 127.0837378083135,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "11",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_984",
+    "statNm": "익명_충전소_984",
+    "addr": "익명_주소",
+    "lat": 37.477334138544634,
+    "lng": 126.98245073742106,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "05",
+        "stat": "9",
+        "output": 50
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_985",
+    "statNm": "익명_충전소_985",
+    "addr": "익명_주소",
+    "lat": 37.515861307376696,
+    "lng": 126.9862447146056,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_986",
+    "statNm": "익명_충전소_986",
+    "addr": "익명_주소",
+    "lat": 37.66033836798139,
+    "lng": 127.02566516450354,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_987",
+    "statNm": "익명_충전소_987",
+    "addr": "익명_주소",
+    "lat": 37.510373606159334,
+    "lng": 127.06814518598576,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 50
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_988",
+    "statNm": "익명_충전소_988",
+    "addr": "익명_주소",
+    "lat": 37.52744035516898,
+    "lng": 126.9756760826641,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1566-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "거주자외 출입제한",
+    "note": "",
+    "totalChargers": 10,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "09",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "10",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_989",
+    "statNm": "익명_충전소_989",
+    "addr": "익명_주소",
+    "lat": 37.57806149032884,
+    "lng": 126.90627020506412,
+    "useTime": "~",
+    "busiNm": "익명_사업자",
+    "busiCall": "1833-XXXX",
+    "parkingFree": false,
+    "limitYn": false,
+    "limitDetail": "시설 상황에 따라 이용이 제한될 수 있음",
+    "note": "",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_990",
+    "statNm": "익명_충전소_990",
+    "addr": "익명_주소",
+    "lat": 37.51046140326556,
+    "lng": 126.91456435391522,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1544-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "관리 시설에 따른 이용 제한이 있을 수 있음 ",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_991",
+    "statNm": "익명_충전소_991",
+    "addr": "익명_주소",
+    "lat": 37.57367029150046,
+    "lng": 127.09727473413434,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 8,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 0
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "07",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      },
+      {
+        "chgerId": "08",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 0
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_992",
+    "statNm": "익명_충전소_992",
+    "addr": "익명_주소",
+    "lat": 37.47779907288184,
+    "lng": 127.0417438018452,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_993",
+    "statNm": "익명_충전소_993",
+    "addr": "익명_주소",
+    "lat": 37.5573795942607,
+    "lng": 127.07289575159139,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_994",
+    "statNm": "익명_충전소_994",
+    "addr": "익명_주소",
+    "lat": 37.48411261043201,
+    "lng": 127.0374308135028,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 6,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "06",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_995",
+    "statNm": "익명_충전소_995",
+    "addr": "익명_주소",
+    "lat": 37.57463146511204,
+    "lng": 127.00527329710364,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_996",
+    "statNm": "익명_충전소_996",
+    "addr": "익명_주소",
+    "lat": 37.5345884603903,
+    "lng": 126.9800475480204,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 2,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_997",
+    "statNm": "익명_충전소_997",
+    "addr": "익명_주소",
+    "lat": 37.57451274531344,
+    "lng": 126.92565024841194,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": true,
+    "limitDetail": "외부인 사용불가",
+    "note": "외부인 사용불가",
+    "totalChargers": 1,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_998",
+    "statNm": "익명_충전소_998",
+    "addr": "익명_주소",
+    "lat": 37.480165888596765,
+    "lng": 126.9735104541099,
+    "useTime": "24시간 이용가능,입주민만 사용가능 거주자외출입제한",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "입주민만 사용가능 거주자외 출입제한",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_999",
+    "statNm": "익명_충전소_999",
+    "addr": "익명_주소",
+    "lat": 37.48594032155487,
+    "lng": 126.97042347922067,
+    "useTime": "24시간 이용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1522-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "",
+    "note": "",
+    "totalChargers": 4,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 100
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "04",
+        "stat": "2",
+        "output": 200
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "06",
+        "stat": "2",
+        "output": 100
+      }
+    ]
+  },
+  {
+    "statId": "익명_ID_1000",
+    "statNm": "익명_충전소_1000",
+    "addr": "익명_주소",
+    "lat": 37.53620854044059,
+    "lng": 127.02795063920847,
+    "useTime": "24시간 이용가능, 아파트 입주민만 사용가능",
+    "busiNm": "익명_사업자",
+    "busiCall": "1661-XXXX",
+    "parkingFree": true,
+    "limitYn": false,
+    "limitDetail": "외부인 사용불가",
+    "note": "",
+    "totalChargers": 5,
+    "chargers": [
+      {
+        "chgerId": "01",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      },
+      {
+        "chgerId": "02",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "03",
+        "chgerType": "02",
+        "stat": "2",
+        "output": 7
+      },
+      {
+        "chgerId": "04",
+        "chgerType": "02",
+        "stat": "9",
+        "output": 7
+      },
+      {
+        "chgerId": "05",
+        "chgerType": "02",
+        "stat": "3",
+        "output": 7
+      }
+    ]
+  }
+]

--- a/dev/src/pages/samples/basicClusterer.tsx
+++ b/dev/src/pages/samples/basicClusterer.tsx
@@ -1,0 +1,143 @@
+import React, { useState, useEffect } from "react"
+import { Map, MapMarker, MarkerClusterer } from "react-kakao-maps-sdk"
+import useKakaoLoader from "./useKakaoLoader"
+
+const BasicClusterer = () => {
+  useKakaoLoader()
+
+  const [positions, setPositions] = useState([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [map, setMap] = useState(null) // 지도 객체를 저장할 state
+
+  useEffect(() => {
+    fetch("/stations.json")
+      .then((response) => response.json())
+      .then((data) => {
+        const pos = data.positions || data
+        if (Array.isArray(pos)) {
+          setPositions(pos)
+        }
+        setIsLoading(false)
+      })
+      .catch((error) => {
+        console.error("stations.json 파일 로딩 중 에러 발생:", error)
+        setIsLoading(false)
+      })
+  }, [])
+
+  useEffect(() => {
+    if (map && !isLoading) {
+      const timer = setTimeout(() => {
+        map.relayout()
+      }, 0)
+
+      return () => {
+        clearTimeout(timer)
+      }
+    }
+  }, [map, isLoading])
+
+  // 지도 레벨을 변경하는 함수
+  const handleZoom = (level) => {
+    if (!map) return
+    //map.setLevel(level)
+    map.setLevel(level, {
+      // 확대/축소 시 부드러운 이동 효과
+      anchor: map.getCenter(),
+      animate: {
+        duration: 300,
+      },
+    })
+  }
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100vh",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {isLoading ? (
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
+          <p>지도 및 데이터 로딩 중...</p>
+        </div>
+      ) : (
+        <Map
+          center={{ lat: 37.566826, lng: 126.9786567 }}
+          style={{ width: "100%", flex: 1 }}
+          level={10}
+          onCreate={setMap} // Map 객체가 생성되면 state에 저장
+        >
+          <MarkerClusterer
+            averageCenter={true} // 클러스터 마커를 클러스터에 포함된 마커들의 평균 위치로 설정
+            minLevel={10} // 클러스터링을 시작할 최소 지도 레벨
+          >
+            {positions.map((pos) => (
+              <MapMarker
+                key={pos.statId} // 데이터의 고유 ID를 key로 사용
+                position={{ lat: pos.lat, lng: pos.lng }}
+              />
+            ))}
+          </MarkerClusterer>
+        </Map>
+      )}
+      <div
+        style={{ padding: "16px", textAlign: "center", background: "#f8f9fa" }}
+      >
+        <button
+          onClick={() => handleZoom(10)}
+          style={{
+            margin: "0 5px",
+            padding: "8px 16px",
+            border: "1px solid #6c757d",
+            backgroundColor: "#6c757d",
+            color: "white",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          지역 클러스터 보기 (level: 10)
+        </button>
+        <button
+          onClick={() => handleZoom(11)}
+          style={{
+            margin: "0 5px",
+            padding: "8px 16px",
+            border: "1px solid #17a2b8",
+            backgroundColor: "#17a2b8",
+            color: "white",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          전체 클러스터 보기 (level: 11)
+        </button>
+        <button
+          onClick={() => handleZoom(9)}
+          style={{
+            margin: "0 5px",
+            padding: "8px 16px",
+            border: "1px solid #28a745",
+            backgroundColor: "#28a745",
+            color: "white",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          마커 보기 (level: 9)
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default BasicClusterer

--- a/packages/react-kakao-maps-sdk/src/components/CustomOverlayMap.tsx
+++ b/packages/react-kakao-maps-sdk/src/components/CustomOverlayMap.tsx
@@ -1,83 +1,90 @@
 import React, {
   useContext,
+  useEffect,
   useImperativeHandle,
   useLayoutEffect,
   useMemo,
+  useRef,
 } from "react"
 import ReactDOM from "react-dom"
 import { useMap } from "../hooks/useMap"
-import { KakaoMapMarkerClustererContext } from "./MarkerClusterer"
+import { MarkerClustererContext } from "./MarkerClusterer"
 import { useKakaoMapsSetEffect } from "../hooks/useKakaoMapsSetEffect"
 
+// --- 타입 정의 ---
+
 export interface CustomOverlayMapProps {
-  /**
-   * 커스텀 오버레이의 좌표
-   */
   position: {
     lat: number
     lng: number
   }
-  /**
-   * true 로 설정하면 컨텐츠 영역을 클릭했을 경우 지도 이벤트를 막아준다.
-   */
   clickable?: boolean
-
-  /**
-   * 컨텐츠의 x축 위치. 0_1 사이의 값을 가진다. 기본값은 0.5
-   */
   xAnchor?: number
-
-  /**
-   * 컨텐츠의 y축 위치. 0_1 사이의 값을 가진다. 기본값은 0.5
-   */
   yAnchor?: number
-
-  /**
-   * 커스텀 오버레이의 z-index
-   */
   zIndex?: number
-
-  /**
-   * 커스텀 오버레이를 생성 후 해당 객체를 가지고 callback 함수를 실행 시켜줌
-   */
   onCreate?: (customOverlay: kakao.maps.CustomOverlay) => void
 }
 
-/**
- * Map에 CustomOverlay를 올릴 때 사용하는 컴포넌트 입니다.
- * `onCreate` 이벤트 또는 `ref` 객체를 통해서 `CustomOverlay` 객체에 직접 접근 및 초기 설정 작업을 지정할 수 있습니다.
- */
+// --- 컴포넌트 구현 ---
+
+let overlayCounter = 0
+
 export const CustomOverlayMap = React.forwardRef<
   kakao.maps.CustomOverlay,
   React.PropsWithChildren<CustomOverlayMapProps>
->(function CustomOverlayMap(
-  { position, children, clickable, xAnchor, yAnchor, zIndex, onCreate },
-  ref,
-) {
-  const markerCluster = useContext(KakaoMapMarkerClustererContext)
+>(function CustomOverlayMap({ children, ...props }, ref) {
+  const map = useMap("CustomOverlayMap")
+  const registry = useContext(MarkerClustererContext)
 
-  const map = useMap(`CustomOverlayMap`)
+  // 고유 ID 생성
+  const id = useRef(overlayCounter++).current
+  const isMounted = useRef(false)
 
-  const overlayPosition = useMemo(() => {
-    return new kakao.maps.LatLng(position.lat, position.lng)
-  }, [position.lat, position.lng])
+  // 클러스터러 하위에 있을 경우, 설명서(Descriptor) 등록/수정/해제 로직
+  useEffect(() => {
+    if (!registry) return
+
+    const descriptor = {
+      id,
+      type: "CustomOverlayMap" as const,
+      props,
+      children,
+    }
+
+    if (!isMounted.current) {
+      registry.register(descriptor)
+      isMounted.current = true
+    } else {
+      // update 호출 시 자신의 타입 "CustomOverlayMap"을 전달
+      registry.update(id, "CustomOverlayMap", props, children)
+    }
+
+    return () => {
+      registry.unregister(id)
+    }
+  }, [registry, id, props, children])
+
+  // 클러스터러 하위에 있을 경우, 렌더링은 부모에게 위임하므로 null 반환
+  if (registry) {
+    return null
+  }
+
+  // --- 이하 독립적으로 사용될 때의 기존 로직 (Fallback) ---
+
+  const overlayPosition = useMemo(
+    () => new kakao.maps.LatLng(props.position.lat, props.position.lng),
+    [props.position.lat, props.position.lng],
+  )
 
   const overlay = useMemo(() => {
     const container = document.createElement("div")
-    container.style.display = "none"
-
-    const KakaoCustomOverlay = new kakao.maps.CustomOverlay({
-      clickable: clickable,
-      xAnchor: xAnchor,
-      yAnchor: yAnchor,
-      zIndex: zIndex,
+    return new kakao.maps.CustomOverlay({
+      ...props,
       position: overlayPosition,
       content: container,
     })
-
-    return KakaoCustomOverlay
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [clickable, xAnchor, yAnchor])
+  }, [props.clickable, props.xAnchor, props.yAnchor])
 
   const container = useMemo(
     () => overlay.getContent() as HTMLElement,
@@ -87,32 +94,16 @@ export const CustomOverlayMap = React.forwardRef<
   useImperativeHandle(ref, () => overlay, [overlay])
 
   useLayoutEffect(() => {
-    if (!map) return
-
-    if (markerCluster) {
-      markerCluster.addMarker(overlay, true)
-    } else {
-      overlay.setMap(map)
-    }
-
-    return () => {
-      if (markerCluster) {
-        markerCluster.removeMarker(overlay, true)
-      } else {
-        overlay.setMap(null)
-      }
-    }
-  }, [map, markerCluster, overlay])
+    overlay.setMap(map)
+    return () => overlay.setMap(null)
+  }, [map, overlay])
 
   useLayoutEffect(() => {
-    if (onCreate) onCreate(overlay)
-  }, [overlay, onCreate])
+    if (props.onCreate) props.onCreate(overlay)
+  }, [overlay, props.onCreate])
 
   useKakaoMapsSetEffect(overlay, "setPosition", overlayPosition)
-  useKakaoMapsSetEffect(overlay, "setZIndex", zIndex!)
+  useKakaoMapsSetEffect(overlay, "setZIndex", props.zIndex!)
 
-  return (
-    container.parentElement &&
-    ReactDOM.createPortal(children, container.parentElement)
-  )
+  return ReactDOM.createPortal(children, container)
 })

--- a/packages/react-kakao-maps-sdk/src/components/MapMarker.tsx
+++ b/packages/react-kakao-maps-sdk/src/components/MapMarker.tsx
@@ -1,164 +1,99 @@
-import React, { useMemo } from "react"
+import React, { useMemo, useEffect, useRef, useContext } from "react"
 import { useMap } from "../hooks/useMap"
 import { Marker } from "./Marker"
+import { MarkerClustererContext } from "./MarkerClusterer"
+
+// =================================================================================================
+// 1. Props 타입 및 컴포넌트 시그니처
+// =================================================================================================
 
 export interface MapMarkerProps {
-  /**
-   * 표시 위치
-   */
-  position:
-    | {
-        lat: number
-        lng: number
-      }
-    | {
-        x: number
-        y: number
-      }
-
+  position: { lat: number; lng: number } | { x: number; y: number }
   image?: {
-    /**
-     * 표시 이미지 src
-     */
     src: string
-
-    /**
-     * 표시 이미지 크기
-     */
-    size: {
-      width: number
-      height: number
-    }
-
+    size: { width: number; height: number }
     options?: {
-      /**
-       * 마커 이미지의 alt 속성값을 정의한다.
-       */
       alt?: string
-
-      /**
-       * 마커의 클릭 또는 마우스오버 가능한 영역을 표현하는 좌표값
-       */
       coords?: string
-
-      /**
-       * 마커의 좌표에 일치시킬 이미지 안의 좌표 (기본값: 이미지의 가운데 아래)
-       */
       offset?: { x: number; y: number }
-
-      /**
-       * 마커의 클릭 또는 마우스오버 가능한 영역의 모양
-       */
       shape?: "default" | "rect" | "circle" | "poly"
-
-      /**
-       * 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
-       */
       spriteOrigin?: { x: number; y: number }
-
-      /**
-       * 스프라이트 이미지의 전체 크기
-       */
       spriteSize?: { width: number; height: number }
     }
   }
-
-  /**
-   * click 이벤트 핸들러
-   */
   onClick?: (marker: kakao.maps.Marker) => void
-
-  /**
-   * mouseover 이벤트 핸들러
-   */
   onMouseOver?: (marker: kakao.maps.Marker) => void
-
-  /**
-   * mouseout 이벤트 핸들러
-   */
   onMouseOut?: (marker: kakao.maps.Marker) => void
-
-  /**
-   * dragstart 이벤트 핸들러
-   */
   onDragStart?: (marker: kakao.maps.Marker) => void
-
-  /**
-   * dragend 이벤트 핸들러
-   */
   onDragEnd?: (marker: kakao.maps.Marker) => void
-
-  /**
-   * Marker 생성 이벤트 핸들러
-   */
   onCreate?: (marker: kakao.maps.Marker) => void
-
-  /**
-   * 마커 엘리먼트의 타이틀 속성 값 (툴팁)
-   */
   title?: string
-
-  /**
-   * 드래그 가능한 마커, 로드뷰에 올릴 경우에는 유효하지 않다.
-   */
   draggable?: boolean
-
-  /**
-   * 클릭 가능한 마커
-   */
   clickable?: boolean
-
-  /**
-   * 마커 엘리먼트의 z-index 속성 값
-   */
   zIndex?: number
-
-  /**
-   * 마커 투명도 (0-1)
-   */
   opacity?: number
-
-  /**
-   * InfoWindow 옵션
-   */
   infoWindowOptions?: {
-    /**
-     * 인포윈도우를 열 때 지도가 자동으로 패닝하지 않을지의 여부 (기본값: false)
-     */
     disableAutoPan?: boolean
-
-    /**
-     * 삭제 가능한 인포윈도우
-     */
     removable?: boolean
-
-    /**
-     * 인포윈도우 엘리먼트의 z-index 속성 값
-     */
     zIndex?: number
   }
 }
 
-/**
- * Map에서 Marker를 생성할 때 사용 합니다.
- * `onCreate` 이벤트를 통해 생성 후 `marker` 객체에 직접 접근하여 초기 설정이 가능합니다.
- */
+let markerCounter = 0
+
+// =================================================================================================
+// 2. 새롭게 구현된 MapMarker 컴포넌트
+// =================================================================================================
+
 export const MapMarker = React.forwardRef<
   kakao.maps.Marker,
   React.PropsWithChildren<MapMarkerProps>
->(function MapMarker({ position, ...args }, ref) {
-  const map = useMap(`MapMarker`)
+>(function MapMarker({ children, ...props }, ref) {
+  const map = useMap("MapMarker")
+  const registry = useContext(MarkerClustererContext)
+
+  const id = useRef(markerCounter++).current
+  const isMounted = useRef(false)
 
   const markerPosition = useMemo(() => {
-    if ("lat" in position) {
-      return new kakao.maps.LatLng(position.lat, position.lng)
+    if ("lat" in props.position) {
+      return new kakao.maps.LatLng(props.position.lat, props.position.lng)
     }
-    return new kakao.maps.Coords(position.x, position.y).toLatLng()
+    return new kakao.maps.Coords(props.position.x, props.position.y).toLatLng()
+  }, [props.position])
 
-    // eslint-disable-next-line
-    // @ts-ignore
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [position.lat, position.lng, position.x, position.y])
+  // --- 클러스터러 하위일 때의 로직 ---
+  useEffect(() => {
+    // registry가 없으면 클러스터러 하위가 아니므로 아무것도 하지 않음
+    if (!registry) return
 
-  return <Marker map={map} position={markerPosition} {...args} ref={ref} />
+    // MarkerClusterer에 전달할 설명서(Descriptor)
+    const descriptor = { id, type: "Marker" as const, props, children }
+
+    if (!isMounted.current) {
+      // 1. [수정됨] 첫 마운트 시, type을 명시하여 등록
+      registry.register(descriptor)
+      isMounted.current = true
+    } else {
+      // 2. [수정됨] 이후 props 변경 시, type과 함께 업데이트 요청
+      registry.update(id, "Marker", props, children)
+    }
+
+    return () => {
+      // 컴포넌트가 사라질 때 클러스터러에서 제거하도록 요청
+      registry.unregister(id)
+    }
+  }, [registry, id, props, children])
+
+  // 클러스터러 하위에 있을 경우, 렌더링은 부모(MarkerClusterer)에게 위임하므로 null 반환
+  if (registry) {
+    return null
+  }
+
+  // --- 클러스터러 하위가 아닐 때의 독립 실행 로직 (Fallback) ---
+  return (
+    <Marker map={map} position={markerPosition} {...props} ref={ref}>
+      {children}
+    </Marker>
+  )
 })

--- a/packages/react-kakao-maps-sdk/src/components/Marker.tsx
+++ b/packages/react-kakao-maps-sdk/src/components/Marker.tsx
@@ -1,176 +1,62 @@
 import React, {
   useContext,
+  useEffect,
   useImperativeHandle,
   useLayoutEffect,
   useMemo,
+  useRef,
 } from "react"
+import { useMap } from "../hooks/useMap"
 import { useKakaoEvent } from "../hooks/useKakaoEvent"
-import { InfoWindow } from "./InfoWindow"
-import { KakaoMapMarkerClustererContext } from "./MarkerClusterer"
 import { useKakaoMapsSetEffect } from "../hooks/useKakaoMapsSetEffect"
+import { MarkerClustererContext } from "./MarkerClusterer"
+import { InfoWindow } from "./InfoWindow"
 
 export interface MarkerProps {
-  map: kakao.maps.Map | kakao.maps.Roadview
-  position: kakao.maps.LatLng | kakao.maps.Viewpoint
-
-  /**
-   * marker 생성 후 marker 객체를 전달하는 callback
-   */
-  onCreate?: (marker: kakao.maps.Marker) => void
-
-  /**
-   * click 이벤트 핸들러
-   */
-  onClick?: (marker: kakao.maps.Marker) => void
-
-  /**
-   * mouseover 이벤트 핸들러
-   */
-  onMouseOver?: (marker: kakao.maps.Marker) => void
-
-  /**
-   * mouseout 이벤트 핸들러
-   */
-  onMouseOut?: (marker: kakao.maps.Marker) => void
-
-  /**
-   * dragstart 이벤트 핸들러
-   */
-  onDragStart?: (marker: kakao.maps.Marker) => void
-
-  /**
-   * dragend 이벤트 핸들러
-   */
-  onDragEnd?: (marker: kakao.maps.Marker) => void
-
-  /**
-   * 마커의 이미지
-   */
+  map?: kakao.maps.Map | kakao.maps.Roadview
+  position: { lat: number; lng: number }
   image?: {
-    /**
-     * 표시 이미지 src
-     */
     src: string
-
-    /**
-     * 표시 이미지 크기
-     */
-    size: {
-      width: number
-      height: number
-    }
-
-    options?: {
-      /**
-       * 마커 이미지의 alt 속성값을 정의한다.
-       */
-      alt?: string
-
-      /**
-       * 마커의 클릭 또는 마우스오버 가능한 영역을 표현하는 좌표값
-       */
-      coords?: string
-
-      /**
-       * 마커의 좌표에 일치시킬 이미지 안의 좌표 (기본값: 이미지의 가운데 아래)
-       */
-      offset?: { x: number; y: number }
-
-      /**
-       * 마커의 클릭 또는 마우스오버 가능한 영역의 모양
-       */
-      shape?: "default" | "rect" | "circle" | "poly"
-
-      /**
-       * 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
-       */
-      spriteOrigin?: { x: number; y: number }
-
-      /**
-       * 스프라이트 이미지의 전체 크기
-       */
-      spriteSize?: { width: number; height: number }
-    }
+    size: { width: number; height: number }
+    options?: kakao.maps.MarkerOptions["image"] extends kakao.maps.MarkerImage
+      ? kakao.maps.MarkerImage["__getOptions"]
+      : never
   }
-
-  /**
-   * 마커 엘리먼트의 타이틀 속성 값 (툴팁)
-   */
   title?: string
-
-  /**
-   * 드래그 가능한 마커, 로드뷰에 올릴 경우에는 유효하지 않다.
-   */
   draggable?: boolean
-
-  /**
-   * 클릭 가능한 마커
-   */
   clickable?: boolean
-
-  /**
-   * 마커 엘리먼트의 z-index 속성 값
-   */
   zIndex?: number
-
-  /**
-   * 마커 투명도 (0-1)
-   */
   opacity?: number
-
-  /**
-   * 로드뷰에 올라있는 마커의 높이 값(m 단위)
-   */
   altitude?: number
-
-  /**
-   * 로드뷰 상에서 마커의 가시반경(m 단위), 두 지점 사이의 거리가 지정한 값보다 멀어지면 마커는 로드뷰에서 보이지 않게 된다.
-   */
   range?: number
-
-  /**
-   * InfoWindow 옵션
-   */
+  onCreate?: (marker: kakao.maps.Marker) => void
+  onClick?: (marker: kakao.maps.Marker) => void
+  onMouseOver?: (marker: kakao.maps.Marker) => void
+  onMouseOut?: (marker: kakao.maps.Marker) => void
+  onDragStart?: (marker: kakao.maps.Marker) => void
+  onDragEnd?: (marker: kakao.maps.Marker) => void
   infoWindowOptions?: {
-    /**
-     * 인포윈도우를 열 때 지도가 자동으로 패닝하지 않을지의 여부 (기본값: false)
-     */
     disableAutoPan?: boolean
-
-    /**
-     * 삭제 가능한 인포윈도우
-     */
     removable?: boolean
-
-    /**
-     * 인포윈도우 엘리먼트의 z-index 속성 값
-     */
     zIndex?: number
-
-    /**
-     * 로드뷰에 올라있는 인포윈도우의 높이 값(m 단위)
-     */
     altitude?: number
-
-    /**
-     * 로드뷰 상에서 인포윈도우의 가시반경(m 단위), 두 지점 사이의 거리가 지정한 값보다 멀어지면 인포윈도우는 보이지 않게 된다
-     */
     range?: number
   }
 }
+
+let markerCounter = 0
 
 export const Marker = React.forwardRef<
   kakao.maps.Marker,
   React.PropsWithChildren<MarkerProps>
 >(function Marker(
   {
-    map,
-    position,
     children,
+    position,
+    image,
     altitude,
     clickable,
     draggable,
-    image,
     infoWindowOptions,
     onCreate,
     onClick,
@@ -182,80 +68,109 @@ export const Marker = React.forwardRef<
     range,
     title,
     zIndex,
+    ...restProps
   },
   ref,
 ) {
-  const markerCluster = useContext(KakaoMapMarkerClustererContext)
+  const map = useMap("Marker")
+  const registry = useContext(MarkerClustererContext)
+
+  const id = useRef(markerCounter++).current
+  const isMounted = useRef(false)
+
+  const allProps = {
+    position,
+    image,
+    altitude,
+    clickable,
+    draggable,
+    infoWindowOptions,
+    onCreate,
+    onClick,
+    onDragEnd,
+    onDragStart,
+    onMouseOut,
+    onMouseOver,
+    opacity,
+    range,
+    title,
+    zIndex,
+    ...restProps,
+  }
+
+  useEffect(() => {
+    if (!registry) return
+
+    const descriptor = {
+      id,
+      type: "Marker" as const,
+      props: allProps,
+      children,
+    }
+
+    if (!isMounted.current) {
+      registry.register(descriptor)
+      isMounted.current = true
+    } else {
+      registry.update(id, "Marker", allProps, children)
+    }
+
+    return () => {
+      registry.unregister(id)
+      isMounted.current = false
+    }
+  }, [registry, id, allProps, children])
+
+  if (registry) {
+    return null
+  }
+
+  // --- 독립적으로 사용될 때의 Fallback 로직 ---
 
   const markerImage = useMemo(() => {
-    return (
-      image &&
-      new kakao.maps.MarkerImage(
-        image.src,
-        new kakao.maps.Size(image.size.width, image.size.height),
-        {
-          alt: image.options?.alt,
-          coords: image.options?.coords,
-          offset:
-            image.options?.offset &&
-            new kakao.maps.Point(
-              image.options?.offset.x,
-              image.options?.offset.y,
-            ),
-          shape: image.options?.shape,
-          spriteOrigin:
-            image.options?.spriteOrigin &&
-            new kakao.maps.Point(
-              image.options?.spriteOrigin.x,
-              image.options?.spriteOrigin.y,
-            ),
-          spriteSize:
-            image.options?.spriteSize &&
-            new kakao.maps.Size(
-              image.options?.spriteSize.width,
-              image.options?.spriteSize.height,
-            ),
-        },
-      )
+    if (!image) return undefined
+    return new kakao.maps.MarkerImage(
+      image.src,
+      new kakao.maps.Size(image.size.width, image.size.height),
+      image.options,
     )
-
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(image)])
 
   const marker = useMemo(() => {
-    const kakaoMarker = new kakao.maps.Marker({
+    return new kakao.maps.Marker({
+      position: new kakao.maps.LatLng(position.lat, position.lng),
+      image: markerImage,
       altitude,
       clickable,
       draggable,
-      image: markerImage,
       opacity,
       range,
       title,
       zIndex,
-      position,
     })
-
-    return kakaoMarker
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useImperativeHandle(ref, () => marker, [marker])
 
   useLayoutEffect(() => {
-    if (markerCluster) {
-      markerCluster.addMarker(marker, true)
-      return () => markerCluster.removeMarker(marker, true)
-    }
-
     marker.setMap(map)
-    return () => marker.setMap(null)
-  }, [map, markerCluster, marker])
+    return () => {
+      marker.setMap(null)
+    }
+  }, [map, marker])
 
   useLayoutEffect(() => {
     if (onCreate) onCreate(marker)
   }, [marker, onCreate])
 
-  useKakaoMapsSetEffect(marker, "setPosition", position)
+  const latlng = useMemo(
+    () => new kakao.maps.LatLng(position.lat, position.lng),
+    [position.lat, position.lng],
+  )
+
+  useKakaoMapsSetEffect(marker, "setPosition", latlng)
   useKakaoMapsSetEffect(marker, "setImage", markerImage!)
   useKakaoMapsSetEffect(marker, "setAltitude", altitude!)
   useKakaoMapsSetEffect(marker, "setClickable", clickable!)
@@ -271,10 +186,10 @@ export const Marker = React.forwardRef<
   useKakaoEvent(marker, "mouseout", onMouseOut)
   useKakaoEvent(marker, "mouseover", onMouseOver)
 
-  if (children)
+  if (children) {
     return (
       <InfoWindow
-        position={position}
+        position={latlng}
         map={map}
         marker={marker}
         altitude={infoWindowOptions?.altitude}
@@ -286,6 +201,7 @@ export const Marker = React.forwardRef<
         {children}
       </InfoWindow>
     )
+  }
 
   return null
 })


### PR DESCRIPTION
카카오맵 react sdk 를 오픈 소스로 구현하고 제공해 주셔서 감사합니다.

이슈 #77 과 관련하여 다음과 같은 코드를 구현해 봤습니다. 관리자님께서 올바른 방향으로 피드백 주시면 개선해 보겠습니다.

- 지도 초기 로드 시 마커가 표시되지 않는 문제를 해결했습니다.
- React 18 StrictMode에서 중복 렌더링이 발생하던 문제를 수정했습니다.
- MarkerClusterer 컴포넌트가 마커의 생명주기를 중앙에서 관리하도록 변경했습니다.
- API 호출 감소를 위해 마커 연산에 일괄 처리(batch processing)를 추가했습니다.
- 실제 로컬 데이터를 이용해 클러스터러를 테스트할 수 있는 예제 (basicClusterer.tsx.tsx)를 추가하였습니다.

MarkerClusterer 과 MapMarker 등을 수정 시, 선언적 서술 단계와 명령형 실행 단계를 분리하여, MarkerClusterer가 여러 마커 작업을 단일 API 호출로 묶어 처리할 수 있도록 합니다. 즉, 자식 컴포넌트(MapMarker, CustomOverlayMap)는 Kakao Map 인스턴스를 직접 생성하는 대신, 설명자(descriptor)를 등록하고 실제 인스턴스 생성은 일괄 처리를 위해 MarkerClusterer에게 위임합니다.

테스트 과정에서 큰 도움을 주신 @HaJi490 님께 감사드립니다! 

관련 이슈: #77 